### PR TITLE
fix(wrcf): align skills panel UI with industry WRCF panel

### DIFF
--- a/apps/api/bff/src/modules/wrcf/routes.ts
+++ b/apps/api/bff/src/modules/wrcf/routes.ts
@@ -80,6 +80,7 @@ export const registerWrcfBffRoutes = (app: FastifyInstanceLike): void => {
   app.route({ method: 'DELETE', url: '/skills/:id', handler: (req, rep) => forwardToCore('DELETE', '/api/wrcf/skills/:id', req, rep) });
   app.route({ method: 'GET', url: '/tasks', handler: (req, rep) => forwardToCore('GET', '/api/wrcf/tasks', req, rep) });
   app.route({ method: 'POST', url: '/tasks', handler: (req, rep) => forwardToCore('POST', '/api/wrcf/tasks', req, rep) });
+  app.route({ method: 'GET', url: '/tasks/:id/can-delete', handler: (req, rep) => forwardToCore('GET', '/api/wrcf/tasks/:id/can-delete', req, rep) });
   app.route({ method: 'PATCH', url: '/tasks/:id', handler: (req, rep) => forwardToCore('PATCH', '/api/wrcf/tasks/:id', req, rep) });
   app.route({ method: 'DELETE', url: '/tasks/:id', handler: (req, rep) => forwardToCore('DELETE', '/api/wrcf/tasks/:id', req, rep) });
   app.route({ method: 'GET', url: '/control-points', handler: (req, rep) => forwardToCore('GET', '/api/wrcf/control-points', req, rep) });

--- a/apps/api/core-api/src/modules/wrcf/routes.ts
+++ b/apps/api/core-api/src/modules/wrcf/routes.ts
@@ -634,6 +634,18 @@ export const registerWrcfRoutes = (app: FastifyInstanceLike, deps: WrcfModuleDep
   });
 
   app.route({
+    method: 'GET',
+    url: '/tasks/:id/can-delete',
+    preHandler: authorizationPreHandler('WRCF.MANAGE'),
+    handler: async (request, reply) => {
+      const { id } = (request.params as { id: string });
+      logger.debug('Checking task deletable', { ...getLogContext(request), taskId: id });
+      const data = await deps.checkTaskDeletable.execute(id);
+      reply.status(200).send({ success: true, data, meta: toApiMeta(request) });
+    }
+  });
+
+  app.route({
     method: 'DELETE',
     url: '/tasks/:id',
     preHandler: authorizationPreHandler('WRCF.MANAGE'),

--- a/apps/api/core-api/src/modules/wrcf/runtime.ts
+++ b/apps/api/core-api/src/modules/wrcf/runtime.ts
@@ -49,6 +49,7 @@ import {
   CreateTaskCommandHandler,
   UpdateTaskCommandHandler,
   DeleteTaskCommandHandler,
+  CheckTaskDeletableQueryHandler,
   CreateControlPointCommandHandler,
   UpdateControlPointCommandHandler,
   DeleteControlPointCommandHandler,
@@ -96,6 +97,7 @@ export interface WrcfModuleDependencies {
   readonly createTask: CreateTaskCommandHandler;
   readonly updateTask: UpdateTaskCommandHandler;
   readonly deleteTask: DeleteTaskCommandHandler;
+  readonly checkTaskDeletable: CheckTaskDeletableQueryHandler;
   readonly listControlPoints: ListControlPointsQueryHandler;
   readonly createControlPoint: CreateControlPointCommandHandler;
   readonly updateControlPoint: UpdateControlPointCommandHandler;
@@ -162,6 +164,7 @@ export const registerWrcfCoreApiRuntime = async (app: FastifyInstanceLike): Prom
     createTask: new CreateTaskCommandHandler(taskRepo),
     updateTask: new UpdateTaskCommandHandler(taskRepo),
     deleteTask: new DeleteTaskCommandHandler(taskRepo),
+    checkTaskDeletable: new CheckTaskDeletableQueryHandler(taskRepo),
     listControlPoints: new ListControlPointsQueryHandler(cpRepo),
     createControlPoint: new CreateControlPointCommandHandler(cpRepo),
     updateControlPoint: new UpdateControlPointCommandHandler(cpRepo),

--- a/apps/web/admin-portal/src/app/pages/wrcf-skills/components/skills-panel/skills-panel.component.css
+++ b/apps/web/admin-portal/src/app/pages/wrcf-skills/components/skills-panel/skills-panel.component.css
@@ -2,10 +2,10 @@
 
 .panel {
   position: fixed;
-  top: 0;
+  top: 64px;
   right: 0;
   width: 560px;
-  height: 100dvh;
+  height: calc(100dvh - 64px - 48px);
   background: #1E293B;
   border-left: 1px solid #484E5D;
   display: flex;
@@ -22,7 +22,7 @@
 }
 
 .panel-header {
-  background: #00BFFF;
+  background: #314DDF;
   height: 56px;
   padding: 0 16px;
   display: flex;
@@ -35,7 +35,7 @@
   font-weight: 500;
   font-size: 20px;
   line-height: 28px;
-  color: #0F172A;
+  color: #E8F0FA;
 }
 
 .panel-actions {
@@ -51,12 +51,12 @@
   font-size: 1rem;
   padding: 4px 6px;
   border-radius: 6px;
-  color: #0F172A;
+  color: #E8F0FA;
   transition: background 0.15s;
 }
 
 .action-btn:hover {
-  background: rgba(0, 0, 0, 0.12);
+  background: rgba(255, 255, 255, 0.15);
 }
 
 .panel-body {
@@ -68,14 +68,6 @@
   gap: 16px;
 }
 
-.error-msg {
-  background: rgba(220, 53, 69, 0.12);
-  border: 1px solid rgba(220, 53, 69, 0.4);
-  border-radius: 6px;
-  padding: 10px 14px;
-  font-size: 13px;
-  color: #fca5a5;
-}
 
 .field {
   display: flex;
@@ -120,6 +112,17 @@
 .field-select:focus {
   outline: none;
   border-color: #00BFFF;
+}
+
+.field-input--readonly {
+  color: #7F94AE;
+  cursor: default;
+  border-color: transparent;
+  background: transparent;
+}
+
+.field-input--readonly:focus {
+  border-color: transparent;
 }
 
 .field-textarea {

--- a/apps/web/admin-portal/src/app/pages/wrcf-skills/components/skills-panel/skills-panel.component.html
+++ b/apps/web/admin-portal/src/app/pages/wrcf-skills/components/skills-panel/skills-panel.component.html
@@ -3,24 +3,68 @@
     <span class="panel-title">{{ title }}</span>
     <div class="panel-actions">
       @if (state.mode === 'edit' && state.data?.canEdit !== false) {
-        <button class="action-btn delete-btn" (click)="onDelete()" title="Delete">🗑</button>
+        <button class="action-btn delete-btn" (click)="onDelete()" title="Delete">
+          <mat-icon svgIcon="lucideIcons:trash-2" class="size-4" />
+        </button>
       }
       @if (state.mode === 'create' || state.data?.canEdit !== false) {
-        <button class="action-btn save-btn" (click)="onSave()" title="Save">✓</button>
+        <button class="action-btn save-btn" (click)="onSave()" title="Save">
+          <mat-icon svgIcon="lucideIcons:check" class="size-4" />
+        </button>
       }
-      <button class="action-btn close-btn" (click)="close.emit()" title="Close">✕</button>
+      <button class="action-btn close-btn" (click)="close.emit()" title="Close">
+        <mat-icon svgIcon="lucideIcons:x" class="size-4" />
+      </button>
     </div>
   </div>
 
+  @if (confirmingDelete) {
+    <div class="absolute inset-0 z-10 flex items-center justify-center bg-[var(--bg-primary)]/80">
+      <div class="flex w-80 flex-col gap-5 rounded-xl border border-[var(--border)] bg-[var(--bg-card)] p-6">
+        <div class="flex flex-col items-center gap-2">
+          <mat-icon svgIcon="lucideIcons:triangle-alert" class="size-8 text-error-400" />
+          <p class="m-0 text-center text-base text-[var(--text-primary)]">Delete this {{ state.entity }}?</p>
+          <p class="m-0 text-center text-sm text-[var(--text-secondary)]">This action cannot be undone.</p>
+        </div>
+        <div class="flex gap-3">
+          <button
+            class="h-10 flex-1 cursor-pointer rounded-[10px] border border-[var(--border)] bg-transparent text-sm text-[var(--text-primary)] transition-colors hover:bg-white/10"
+            (click)="onCancelDelete()"
+          >Cancel</button>
+          <button
+            class="h-10 flex-1 cursor-pointer rounded-[10px] border-none bg-error-600 text-sm text-white transition-colors hover:bg-error-700"
+            (click)="onConfirmDelete()"
+          >Delete</button>
+        </div>
+      </div>
+    </div>
+  }
+
   <div class="panel-body">
+    @if (panelError) {
+      <div class="flex items-start gap-2 rounded-lg border border-error-500/50 bg-error-900/20 px-3 py-2.5 text-sm text-error-400">
+        <mat-icon svgIcon="lucideIcons:circle-alert" class="size-4 shrink-0 mt-0.5" />
+        <span>{{ panelError }}</span>
+      </div>
+    }
     @if (errorMsg) {
-      <div class="error-msg">{{ errorMsg }}</div>
+      <div class="flex items-start gap-2 rounded-lg border border-error-500/50 bg-error-900/20 px-3 py-2.5 text-sm text-error-400">
+        <mat-icon svgIcon="lucideIcons:circle-alert" class="size-4 shrink-0 mt-0.5" />
+        <span>{{ errorMsg }}</span>
+      </div>
     }
 
     @if (state.entity === 'Skill') {
       <div class="field">
         <label class="field-label">Name <span class="required">*</span></label>
-        <input class="field-input" type="text" placeholder="Enter skill name..." [(ngModel)]="skillName" />
+        <input
+          class="field-input"
+          [class.field-input--readonly]="state.mode === 'edit'"
+          type="text"
+          placeholder="Enter skill name..."
+          [(ngModel)]="skillName"
+          [readonly]="state.mode === 'edit'"
+        />
       </div>
       <div class="field">
         <label class="field-label">Description</label>
@@ -59,7 +103,14 @@
     @if (state.entity === 'Task') {
       <div class="field">
         <label class="field-label">Name <span class="required">*</span></label>
-        <input class="field-input" type="text" placeholder="Enter task name..." [(ngModel)]="taskName" />
+        <input
+          class="field-input"
+          [class.field-input--readonly]="state.mode === 'edit'"
+          type="text"
+          placeholder="Enter task name..."
+          [(ngModel)]="taskName"
+          [readonly]="state.mode === 'edit'"
+        />
       </div>
       <div class="field">
         <label class="field-label">Description <span class="required">*</span></label>
@@ -99,7 +150,14 @@
     @if (state.entity === 'ControlPoint') {
       <div class="field">
         <label class="field-label">Name <span class="required">*</span></label>
-        <input class="field-input" type="text" placeholder="Enter control point name..." [(ngModel)]="cpName" />
+        <input
+          class="field-input"
+          [class.field-input--readonly]="state.mode === 'edit'"
+          type="text"
+          placeholder="Enter control point name..."
+          [(ngModel)]="cpName"
+          [readonly]="state.mode === 'edit'"
+        />
       </div>
       <div class="field">
         <label class="field-label">Description</label>

--- a/apps/web/admin-portal/src/app/pages/wrcf-skills/components/skills-panel/skills-panel.component.ts
+++ b/apps/web/admin-portal/src/app/pages/wrcf-skills/components/skills-panel/skills-panel.component.ts
@@ -1,23 +1,27 @@
 import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { MatIconModule } from '@angular/material/icon';
 import type { ProficiencyLevel } from '../../../industry-wrcf/models/wrcf.models';
 import type { SkillsPanelState, SkillItem, TaskItem, ControlPointItem } from '../../models/wrcf-skills.models';
 
 @Component({
   selector: 'whizard-skills-panel',
   standalone: true,
-  imports: [FormsModule],
+  imports: [FormsModule, MatIconModule],
   templateUrl: './skills-panel.component.html',
   styleUrl: './skills-panel.component.css'
 })
 export class SkillsPanelComponent implements OnChanges {
   @Input() state!: SkillsPanelState;
   @Input() proficiencyLevels: ProficiencyLevel[] = [];
+  @Input() panelError = '';
   @Output() save = new EventEmitter<Partial<SkillItem | TaskItem | ControlPointItem>>();
+  @Output() deleteRequested = new EventEmitter<void>();
   @Output() delete = new EventEmitter<string>();
   @Output() close = new EventEmitter<void>();
 
   protected errorMsg = '';
+  protected confirmingDelete = false;
 
   // Skill fields
   protected skillName = '';
@@ -62,6 +66,7 @@ export class SkillsPanelComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['state']) {
       this.errorMsg = '';
+      this.confirmingDelete = false;
       this.populateForm();
     }
   }
@@ -179,8 +184,21 @@ export class SkillsPanelComponent implements OnChanges {
   }
 
   protected onDelete(): void {
+    this.deleteRequested.emit();
+  }
+
+  public showDeleteConfirmation(): void {
+    this.confirmingDelete = true;
+  }
+
+  protected onConfirmDelete(): void {
     if (this.state.data) {
       this.delete.emit(this.state.data.id);
     }
+    this.confirmingDelete = false;
+  }
+
+  protected onCancelDelete(): void {
+    this.confirmingDelete = false;
   }
 }

--- a/apps/web/admin-portal/src/app/pages/wrcf-skills/services/wrcf-skills-api.service.ts
+++ b/apps/web/admin-portal/src/app/pages/wrcf-skills/services/wrcf-skills-api.service.ts
@@ -46,6 +46,10 @@ export class WrcfSkillsApiService {
     return this.http.delete<void>(`${this.base}/tasks/${id}`);
   }
 
+  checkTaskDeletable(id: string): Observable<{ canDelete: boolean; reason?: string }> {
+    return this.http.get<ApiEnvelope<{ canDelete: boolean; reason?: string }>>(`${this.base}/tasks/${id}/can-delete`).pipe(map(r => r.data));
+  }
+
   listControlPoints(taskId: string): Observable<ControlPointItem[]> {
     return this.http.get<ApiEnvelope<ControlPointItem[]>>(`${this.base}/control-points?taskId=${taskId}`).pipe(map(r => r.data));
   }

--- a/apps/web/admin-portal/src/app/pages/wrcf-skills/wrcf-skills.component.css
+++ b/apps/web/admin-portal/src/app/pages/wrcf-skills/wrcf-skills.component.css
@@ -292,7 +292,10 @@
 
 .panel-backdrop {
   position: fixed;
-  inset: 0;
+  top: 64px;
+  left: 0;
+  right: 0;
+  bottom: 48px;
   background: rgba(15, 23, 42, 0.6);
   z-index: 190;
 }

--- a/apps/web/admin-portal/src/app/pages/wrcf-skills/wrcf-skills.component.html
+++ b/apps/web/admin-portal/src/app/pages/wrcf-skills/wrcf-skills.component.html
@@ -95,7 +95,8 @@
 
   @if (panel().open) {
   <div class="panel-backdrop" (click)="closePanel()"></div>
-  <whizard-skills-panel [state]="panel()" [proficiencyLevels]="allProficienciesPublic" (save)="onPanelSave($event)"
+  <whizard-skills-panel #panelRef [state]="panel()" [proficiencyLevels]="allProficienciesPublic"
+    [panelError]="panelError()" (save)="onPanelSave($event)" (deleteRequested)="onPanelDeleteRequested()"
     (delete)="onPanelDelete($event)" (close)="closePanel()" />
   }
 

--- a/apps/web/admin-portal/src/app/pages/wrcf-skills/wrcf-skills.component.ts
+++ b/apps/web/admin-portal/src/app/pages/wrcf-skills/wrcf-skills.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, OnInit } from '@angular/core';
+import { Component, inject, signal, OnInit, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterLink, ActivatedRoute } from '@angular/router';
 import { ScrollbarDirective } from '@whizard/shared-ui';
@@ -18,6 +18,8 @@ import { WrcfSkillsApiService } from './services/wrcf-skills-api.service';
   styleUrl: './wrcf-skills.component.css'
 })
 export class WrcfSkillsComponent implements OnInit {
+  @ViewChild('panelRef') private panelRef?: SkillsPanelComponent;
+
   private readonly route = inject(ActivatedRoute);
   private readonly wrcfApi = inject(WrcfApiService);
   private readonly skillsApi = inject(WrcfSkillsApiService);
@@ -57,6 +59,7 @@ export class WrcfSkillsComponent implements OnInit {
 
   protected panel = signal<SkillsPanelState>({ open: false, mode: 'create', entity: 'Skill' });
   protected errorMessage = signal('');
+  protected panelError = signal('');
   protected toastMessage = signal('');
   protected noIndustry = signal(false);
 
@@ -208,6 +211,9 @@ export class WrcfSkillsComponent implements OnInit {
     this.selectedProficiencyId.set('');
     this.resolvedCiId.set(null);
     this.clearSkillsDown();
+    if (swoId) {
+      this.restoreSelectionFromQuery();
+    }
   }
 
   protected onCapabilityChange(capabilityId: string): void {
@@ -305,14 +311,38 @@ export class WrcfSkillsComponent implements OnInit {
   }
 
   private loadSkills(ciId: string): void {
-    this.skillsApi.listSkills(ciId).subscribe({
-      next: skills => this.skills.set(skills),
-      error: () => this.skills.set([])
-    });
     this.selectedSkill.set(null);
     this.tasks.set([]);
     this.selectedTask.set(null);
     this.controlPoints.set([]);
+    this.skillsApi.listSkills(ciId).subscribe({
+      next: skills => {
+        this.skills.set(skills);
+        if (skills.length > 0) this.selectSkill(skills[0]);
+      },
+      error: () => this.skills.set([])
+    });
+  }
+
+  private selectSkill(skill: SkillItem): void {
+    this.selectedSkill.set(skill);
+    this.selectedTask.set(null);
+    this.controlPoints.set([]);
+    this.skillsApi.listTasks(skill.id).subscribe({
+      next: tasks => {
+        this.tasks.set(tasks);
+        if (tasks.length > 0) this.selectTask(tasks[0]);
+      },
+      error: () => this.tasks.set([])
+    });
+  }
+
+  private selectTask(task: TaskItem): void {
+    this.selectedTask.set(task);
+    this.skillsApi.listControlPoints(task.id).subscribe({
+      next: cps => this.controlPoints.set(cps),
+      error: () => this.controlPoints.set([])
+    });
   }
 
   private clearSkillsDown(): void {
@@ -325,28 +355,22 @@ export class WrcfSkillsComponent implements OnInit {
 
   protected onSkillSelect(item: WrcfEntity): void {
     const skill = this.skills().find(s => s.id === item.id) ?? null;
-    this.selectedSkill.set(skill);
-    this.selectedTask.set(null);
-    this.controlPoints.set([]);
     if (skill) {
-      this.skillsApi.listTasks(skill.id).subscribe({
-        next: tasks => this.tasks.set(tasks),
-        error: () => this.tasks.set([])
-      });
+      this.selectSkill(skill);
     } else {
+      this.selectedSkill.set(null);
       this.tasks.set([]);
+      this.selectedTask.set(null);
+      this.controlPoints.set([]);
     }
   }
 
   protected onTaskSelect(item: WrcfEntity): void {
     const task = this.tasks().find(t => t.id === item.id) ?? null;
-    this.selectedTask.set(task);
     if (task) {
-      this.skillsApi.listControlPoints(task.id).subscribe({
-        next: cps => this.controlPoints.set(cps),
-        error: () => this.controlPoints.set([])
-      });
+      this.selectTask(task);
     } else {
+      this.selectedTask.set(null);
       this.controlPoints.set([]);
     }
   }
@@ -366,7 +390,35 @@ export class WrcfSkillsComponent implements OnInit {
   }
 
   protected closePanel(): void {
+    this.panelError.set('');
     this.panel.set({ ...this.panel(), open: false });
+  }
+
+  protected onPanelDeleteRequested(): void {
+    const { entity, data } = this.panel();
+    if (entity === 'Skill') {
+      if (this.tasks().length > 0) {
+        this.panelError.set('Cannot delete Skill with existing Task available.');
+      } else {
+        this.panelError.set('');
+        this.panelRef?.showDeleteConfirmation();
+      }
+    } else if (entity === 'Task' && data) {
+      this.skillsApi.checkTaskDeletable(data.id).subscribe({
+        next: ({ canDelete, reason }) => {
+          if (!canDelete) {
+            this.panelError.set(reason ?? 'Cannot delete Task with existing Control Point available.');
+          } else {
+            this.panelError.set('');
+            this.panelRef?.showDeleteConfirmation();
+          }
+        },
+        error: () => this.panelError.set('Failed to check delete eligibility.')
+      });
+    } else {
+      this.panelError.set('');
+      this.panelRef?.showDeleteConfirmation();
+    }
   }
 
   protected onPanelSave(payload: Partial<SkillItem | TaskItem | ControlPointItem>): void {

--- a/libs/contexts/capability-framework/src/application/command-handlers/task.handlers.ts
+++ b/libs/contexts/capability-framework/src/application/command-handlers/task.handlers.ts
@@ -49,3 +49,15 @@ export class DeleteTaskCommandHandler {
     await this.repo.delete(cmd.id);
   }
 }
+
+export class CheckTaskDeletableQueryHandler {
+  constructor(private readonly repo: ITaskRepository) {}
+
+  async execute(id: string): Promise<{ canDelete: boolean; reason?: string }> {
+    const hasControlPoints = await this.repo.hasControlPoints(id);
+    if (hasControlPoints) {
+      return { canDelete: false, reason: 'Cannot delete Task with existing Control Point available.' };
+    }
+    return { canDelete: true };
+  }
+}

--- a/libs/contexts/capability-framework/src/domain/repositories/task.repository.ts
+++ b/libs/contexts/capability-framework/src/domain/repositories/task.repository.ts
@@ -19,4 +19,5 @@ export interface ITaskRepository {
   save(task: Task): Promise<void>;
   update(task: Task): Promise<void>;
   delete(id: string): Promise<void>;
+  hasControlPoints(id: string): Promise<boolean>;
 }

--- a/libs/contexts/capability-framework/src/infrastructure/persistence/postgres/repositories/prisma-task.repository.ts
+++ b/libs/contexts/capability-framework/src/infrastructure/persistence/postgres/repositories/prisma-task.repository.ts
@@ -99,4 +99,11 @@ export class PrismaTaskRepository implements ITaskRepository {
   async delete(id: string): Promise<void> {
     await this.prisma.task.update({ where: { id: BigInt(id) }, data: { isActive: false } });
   }
+
+  async hasControlPoints(id: string): Promise<boolean> {
+    const count = await this.prisma.controlPoint.count({
+      where: { taskId: BigInt(id), isActive: true }
+    });
+    return count > 0;
+  }
 }

--- a/libs/contexts/capability-framework/src/tests/unit/list-tasks.handler.spec.ts
+++ b/libs/contexts/capability-framework/src/tests/unit/list-tasks.handler.spec.ts
@@ -9,7 +9,8 @@ const makeRepo = (): ITaskRepository => ({
   findById: vi.fn(),
   save: vi.fn(),
   update: vi.fn(),
-  delete: vi.fn()
+  delete: vi.fn(),
+  hasControlPoints: vi.fn()
 });
 
 const taskDto = (overrides: Partial<TaskDto> = {}): TaskDto => ({

--- a/libs/contexts/capability-framework/src/tests/unit/task.handlers.spec.ts
+++ b/libs/contexts/capability-framework/src/tests/unit/task.handlers.spec.ts
@@ -14,7 +14,8 @@ const makeRepo = (): ITaskRepository => ({
   findById: vi.fn(),
   save: vi.fn(),
   update: vi.fn(),
-  delete: vi.fn()
+  delete: vi.fn(),
+  hasControlPoints: vi.fn()
 });
 
 const createCmd = {


### PR DESCRIPTION
* Make name field readonly in edit mode for Skill, Task, and ControlPoint (matches FG/PWO/SWO behaviour in wrcf-panel)
* Match panel overlay layout: top 64px, height calc(100dvh-64px-48px), action-blue header (#314DDF), light text/icon colours
* Fix panel-backdrop to respect header/footer bounds (top 64px, bottom 48px) instead of covering full viewport
* Replace emoji action buttons with mat-icon (trash-2, check, x)
* Update delete confirm overlay and error display to match wrcf-panel markup (var() Tailwind syntax, triangle-alert/circle-alert icons)
* Add `can-delete` endpoint for tasks (BFF + core-api route, handler, runtime wiring) and gate delete from skills panel on that check
* Add `panelError` signal and `onPanelDeleteRequested` guard: blocks skill delete when tasks exist, task delete when CPs exist