### PR TITLE
feat(shared-ui): add confirmation, loading-bar, and toaster services

### DIFF
--- a/apps/web/admin-portal/src/app/app.config.ts
+++ b/apps/web/admin-portal/src/app/app.config.ts
@@ -8,7 +8,7 @@ import { provideNativeDateAdapter } from '@angular/material/core';
 import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 import { ActivatedRouteSnapshot, DetachedRouteHandle, RouteReuseStrategy, provideRouter, withRouterConfig } from '@angular/router';
 import { provideIcons } from '@whizard/icons';
-import { LAYOUT_AUTH_SERVICE, NAVIGATION_ITEMS, SIGNED_URL_PROVIDER,LAYOUT_TENANT_SERVICE } from '@whizard/shared-ui';
+import { LAYOUT_AUTH_SERVICE, NAVIGATION_ITEMS, SIGNED_URL_PROVIDER,LAYOUT_TENANT_SERVICE, loadingInterceptor } from '@whizard/shared-ui';
 import { provideTheming } from '@whizard/theme';
 import { routes } from './app.routes';
 import { ADMIN_NAVIGATION } from './core/data/navigation';
@@ -39,7 +39,7 @@ export const appConfig: ApplicationConfig = {
     }),
 
     provideRouter(routes, withRouterConfig({ onSameUrlNavigation: 'reload' })),
-    provideHttpClient(withInterceptors([authInterceptor])),
+    provideHttpClient(withInterceptors([authInterceptor, loadingInterceptor])),
 
     {
       provide: APP_INITIALIZER,

--- a/apps/web/admin-portal/src/app/pages/manage-internship/components/internship-detail-panel/internship-detail-panel.component.html
+++ b/apps/web/admin-portal/src/app/pages/manage-internship/components/internship-detail-panel/internship-detail-panel.component.html
@@ -59,14 +59,16 @@
               {{ internship()!.title }}
             </h2>
 
-            <button
-              type="button"
-              (click)="editClicked.emit()"
-              class="mr-[10%] shrink-0 flex items-center gap-1.5 h-8 px-3 rounded-lg bg-whizard-action text-white text-sm font-medium hover:bg-whizard-action-hover transition-colors"
-            >
-              <mat-icon svgIcon="lucideIcons:pencil" class="size-4 shrink-0" />
-              Edit
-            </button>
+            @if (internship()!.status !== 'PUBLISHED') {
+              <button
+                type="button"
+                (click)="editClicked.emit()"
+                class="mr-[10%] shrink-0 flex items-center gap-1.5 h-8 px-3 rounded-lg bg-whizard-action text-white text-sm font-medium hover:bg-whizard-action-hover transition-colors"
+              >
+                <mat-icon svgIcon="lucideIcons:pencil" class="size-4 shrink-0" />
+                Edit
+              </button>
+            }
           </div>
 
           <!-- Row 2: meta chips (left) · ID + Date (right) -->
@@ -367,13 +369,15 @@
                   <div
                     class="w-55 h-37.5 rounded-lg border border-white overflow-hidden relative"
                   >
-                    @if (a.pdfUrl) {
-                      <img
-                        [src]="a.pdfUrl | signedUrl"
-                        [alt]="a.title"
-                        class="w-full h-full object-cover"
-                      />
-                    } @else {
+                    <!-- @if (a.pdfUrl) { -->
+                    <img
+                      [src]="
+                        '/assets/images/9e4d51680fac6f3feddbd434414b3ef1ce73c91e.png'
+                      "
+                      [alt]="a.title"
+                      class="w-full h-full object-cover"
+                    />
+                    <!-- } @else {
                       <div
                         class="w-full h-full bg-whizard-bg-secondary flex items-center justify-center"
                       >
@@ -382,7 +386,7 @@
                           class="size-10 text-whizard-text-secondary"
                         />
                       </div>
-                    }
+                    } -->
                     <div
                       class="absolute bottom-0 left-0 right-0 bg-white flex items-center justify-center px-3.5 py-1.5 rounded-b-lg"
                     >
@@ -436,10 +440,17 @@
                 <div
                   class="w-full h-full bg-whizard-bg-secondary flex items-center justify-center"
                 >
-                  <mat-icon
+                  <img
+                    [src]="
+                      '/assets/images/9e4d51680fac6f3feddbd434414b3ef1ce73c91e.png'
+                    "
+                    [alt]="a.title"
+                    class="w-full h-full object-cover"
+                  />
+                  <!-- <mat-icon
                     svgIcon="lucideIcons:clipboard-list"
                     class="size-10 text-whizard-text-secondary"
-                  />
+                  /> -->
                 </div>
                 <div
                   class="absolute bottom-0 left-0 right-0 bg-white flex items-center justify-center px-3.5 py-1.5 rounded-b-lg"
@@ -519,7 +530,7 @@
                       'Offer Letter Template'
                     )
                   "
-                  class="shrink-0 flex items-center gap-1.5 h-[35px] px-4 rounded-lg bg-whizard-accent text-whizard-bg-primary text-sm font-medium hover:opacity-90 transition-opacity"
+                  class="flex items-center gap-1.5 h-8.75 px-4 rounded-lg bg-whizard-action hover:bg-whizard-action-hover transition-colors"
                 >
                   <mat-icon svgIcon="lucideIcons:eye" class="size-4" />
                   View
@@ -539,7 +550,7 @@
                       'Terms & Conditions'
                     )
                   "
-                  class="shrink-0 flex items-center gap-1.5 h-[35px] px-4 rounded-lg bg-whizard-accent text-whizard-bg-primary text-sm font-medium hover:opacity-90 transition-opacity"
+                  class="flex items-center gap-1.5 h-8.75 px-4 rounded-lg bg-whizard-action hover:bg-whizard-action-hover transition-colors"
                 >
                   <mat-icon svgIcon="lucideIcons:eye" class="size-4" />
                   View
@@ -659,13 +670,15 @@
                 <div
                   class="w-55 h-37.5 rounded-lg border border-white overflow-hidden relative"
                 >
-                  @if (c.pdfUrl) {
-                    <img
-                      [src]="c.pdfUrl | signedUrl"
-                      [alt]="c.name"
-                      class="w-full h-full object-cover"
-                    />
-                  } @else {
+                  <!-- @if (c.pdfUrl) { -->
+                  <img
+                    [src]="
+                      '/assets/images/9e4d51680fac6f3feddbd434414b3ef1ce73c91e.png'
+                    "
+                    [alt]="c.name"
+                    class="w-full h-full object-cover"
+                  />
+                  <!-- } @else {
                     <div
                       class="w-full h-full bg-whizard-bg-secondary flex items-center justify-center"
                     >
@@ -674,7 +687,7 @@
                         class="size-10 text-whizard-text-secondary"
                       />
                     </div>
-                  }
+                  } -->
                   <div
                     class="absolute bottom-0 left-0 right-0 bg-white flex items-center justify-center px-3.5 py-1.5 rounded-b-lg"
                   >
@@ -703,13 +716,15 @@
                 <div
                   class="w-55 h-37.5 rounded-lg border border-white overflow-hidden relative"
                 >
-                  @if (a.pdfUrl) {
-                    <img
-                      [src]="a.pdfUrl | signedUrl"
-                      [alt]="a.name"
-                      class="w-full h-full object-cover"
-                    />
-                  } @else {
+                  <!-- @if (a.pdfUrl) { -->
+                  <img
+                    [src]="
+                      '/assets/images/9e4d51680fac6f3feddbd434414b3ef1ce73c91e.png'
+                    "
+                    [alt]="a.name"
+                    class="w-full h-full object-cover"
+                  />
+                  <!-- } @else {
                     <div
                       class="w-full h-full bg-whizard-bg-secondary flex items-center justify-center"
                     >
@@ -718,7 +733,7 @@
                         class="size-10 text-whizard-text-secondary"
                       />
                     </div>
-                  }
+                  } -->
                   <div
                     class="absolute bottom-0 left-0 right-0 bg-white flex items-center justify-center px-3.5 py-1.5 rounded-b-lg"
                   >

--- a/apps/web/admin-portal/src/app/pages/manage-internship/manage-internship.component.html
+++ b/apps/web/admin-portal/src/app/pages/manage-internship/manage-internship.component.html
@@ -25,21 +25,6 @@
     </div>
   }
 
-  <!-- Company selector — visible to ADMIN and SYSTEM users -->
-  @if (isAdminOrSystemUser()) {
-    <div class="shrink-0 flex items-center gap-3 px-6 h-[48px] border-b border-wrcf-border bg-wrcf-bg-primary">
-      <span class="text-[13px] text-wrcf-text-secondary shrink-0">Company</span>
-      <select
-        class="max-w-[280px] h-[36px] px-3 rounded-[10px] bg-wrcf-bg-secondary border border-wrcf-border text-[13px] text-wrcf-text-primary focus:outline-none"
-        (change)="onCompanySelected($any($event.target).value)"
-      >
-        @for (co of companies(); track co.id) {
-          <option [value]="co.tenantId">{{ co.name }}</option>
-        }
-      </select>
-    </div>
-  }
-
   <!-- Main workspace -->
   @if (mode() === 'list') {
     <div class="flex-1 flex overflow-hidden">

--- a/docs/plans/confirmation-dialog.md
+++ b/docs/plans/confirmation-dialog.md
@@ -1,0 +1,230 @@
+# Plan: Shared Confirmation Dialog (`@whizard/shared-ui`)
+
+## Overview
+
+A reusable, injectable confirmation dialog service for all Whizard web portals. Any component can call `confirm.open({ ... })` and receive a `MatDialogRef` that resolves with `'confirmed' | 'cancelled' | undefined` via `afterClosed()`. The visual design follows Figma node `3117:89815` (Latest Whizard Web Design System → Dialog Box), with four semantic variants (info, success, warning, error).
+
+Ported and adapted from the Fuse `FuseConfirmationService` pattern (`src/@fuse/services/confirmation`), modernized for Angular 21 standalone + `providedIn: 'root'` + `inject()` + WRCF dark theme + lucide icons (no heroicons).
+
+---
+
+## Location
+
+```
+libs/shared/ui/src/confirmation/
+├── confirmation.types.ts                       # Config + color unions + result type
+├── confirmation.service.ts                     # Injectable service
+├── dialog/
+│   ├── confirmation-dialog.component.ts        # Standalone component
+│   └── confirmation-dialog.component.html      # Template
+└── index.ts                                    # Folder barrel
+```
+
+Re-exported from `libs/shared/ui/src/index.ts`, consumable as:
+
+```ts
+import {
+  ConfirmationService,
+  WhizardConfirmationConfig,
+  ConfirmationDialogResult,
+} from '@whizard/shared-ui';
+```
+
+---
+
+## Public API
+
+```ts
+@Injectable({ providedIn: 'root' })
+class ConfirmationService {
+  open(
+    config?: WhizardConfirmationConfig,
+  ): MatDialogRef<ConfirmationDialogComponent, ConfirmationDialogResult>;
+}
+
+interface WhizardConfirmationConfig {
+  title?: string;
+  message?: string;
+  icon?: {
+    show?: boolean;
+    name?: string;                   // lucide svgIcon, e.g. 'lucideIcons:info'
+    color?: ConfirmationIconColor;
+  };
+  actions?: {
+    confirm?: { show?: boolean; label?: string; color?: ConfirmationActionColor };
+    cancel?:  { show?: boolean; label?: string };
+  };
+  dismissible?: boolean;
+}
+
+type ConfirmationIconColor =
+  | 'primary' | 'accent' | 'warn' | 'basic'
+  | 'info' | 'success' | 'warning' | 'error';
+
+type ConfirmationActionColor =
+  | 'primary' | 'accent' | 'info' | 'success' | 'warning' | 'error' | 'warn';
+
+type ConfirmationDialogResult = 'confirmed' | 'cancelled' | undefined;
+```
+
+### Default config (service)
+
+| Field                 | Default                           |
+|-----------------------|-----------------------------------|
+| `title`               | `'Confirm action'`                |
+| `message`             | `'Are you sure you want to confirm this action?'` |
+| `icon.show`           | `true`                            |
+| `icon.name`           | `'lucideIcons:triangle-alert'`    |
+| `icon.color`          | `'warning'`                       |
+| `actions.confirm.label` | `'Confirm'`                     |
+| `actions.confirm.color` | `'error'`                       |
+| `actions.cancel.label`  | `'Cancel'`                      |
+| `dismissible`         | `false`                           |
+
+Caller-supplied fields are merged shallowly with nested keys for `icon`, `actions.confirm`, `actions.cancel` — no `lodash.merge` dependency.
+
+---
+
+## Figma → CSS mapping
+
+Source: Figma node `3117:89815`.
+
+| Layer                       | Spec                                                            |
+|-----------------------------|-----------------------------------------------------------------|
+| Panel                       | 499×auto, `border-radius: 16px`, `bg: rgba(30,41,59,0.94)`, `shadow: 0 8px 36px rgba(0,0,0,.16)` |
+| Header                      | `padding: 24 24 0`, flex row, gap 12                            |
+| Icon badge                  | 40×40, `border-radius: 9999px`, tinted bg per variant           |
+| Icon glyph                  | 24×24 lucide svgIcon, colored to match variant                  |
+| Title                       | Red Hat Display, 19/24, weight 700, `#E8F0FA`                   |
+| Close X (when dismissible)  | 32×32 button, lucide `x`, `#7F94AE` → `#E8F0FA` on hover        |
+| Body                        | `padding: 10 24 20 76`, aligned past the icon column            |
+| Message                     | 14/20, regular, `#7F94AE`, `white-space: pre-wrap`              |
+| Actions bar                 | `height: 60`, `padding: 15`, right-aligned, gap 8, `bg: rgba(15,23,42,.6)`, `border-top: 1px solid rgba(72,78,93,.6)` |
+| Cancel button               | 100×42, transparent, `border: 1px solid #484E5D`, white text    |
+| Confirm button              | 100×42, white text, bg driven by `[data-color]`                 |
+
+### Variant color table
+
+| Variant   | Icon bg / text              | Confirm button bg |
+|-----------|-----------------------------|-------------------|
+| `info`    | `rgba(0,132,255,.1)` / `#0084FF`  | `#314DDF`      |
+| `success` | `rgba(1,225,123,.1)` / `#01E17B`  | `#28A745`      |
+| `warning` | `rgba(253,205,15,.12)` / `#FDCD0F` | `#FFA500`     |
+| `error`   | `rgba(240,67,73,.1)` / `#F04349`  | `#F04349`      |
+| `accent`  | `rgba(49,77,223,.12)` / `#314DDF` | `#00BFFF`      |
+
+### Mat Dialog overrides
+
+Declared with `ViewEncapsulation.None` and the panel class `whizard-confirmation-dialog-panel`:
+
+```scss
+.whizard-confirmation-dialog-panel .mat-mdc-dialog-surface {
+  background: transparent !important;
+  box-shadow: none !important;
+  border-radius: 16px !important;
+  padding: 0 !important;
+  overflow: hidden;
+}
+```
+
+The inner `.whizard-confirmation` element owns the real background/shadow so the Figma `rgba(30,41,59,.94)` tint renders cleanly.
+
+---
+
+## Icons
+
+Lucide-only. Icons are registered via `provideIcons()` in `libs/shared/icons/src/lib/icons.provider.ts`, namespace `lucideIcons` (viewBox `0 0 24 24`). Recommended glyphs:
+
+| Variant   | `icon.name`                    |
+|-----------|--------------------------------|
+| `info`    | `'lucideIcons:info'`           |
+| `success` | `'lucideIcons:circle-check'`   |
+| `warning` | `'lucideIcons:triangle-alert'` |
+| `error`   | `'lucideIcons:circle-alert'` or `'lucideIcons:octagon-alert'` |
+| Close X   | `'lucideIcons:x'` (hard-coded in template) |
+
+---
+
+## Usage
+
+```ts
+import { inject } from '@angular/core';
+import { ConfirmationService } from '@whizard/shared-ui';
+
+export class SomeComponent {
+  private readonly confirm = inject(ConfirmationService);
+
+  deleteItem(id: string): void {
+    this.confirm
+      .open({
+        title: 'Delete item?',
+        message: 'This action cannot be undone.',
+        icon: { show: true, name: 'lucideIcons:circle-alert', color: 'error' },
+        actions: {
+          confirm: { label: 'Delete', color: 'error' },
+          cancel:  { label: 'Cancel' },
+        },
+        dismissible: true,
+      })
+      .afterClosed()
+      .subscribe((result) => {
+        if (result === 'confirmed') {
+          // perform delete
+        }
+      });
+  }
+}
+```
+
+### Four Figma variants
+
+```ts
+// Info
+this.confirm.open({
+  title: 'Active Session Found',
+  message: "You're already logged in on another device. Continuing here will log you out from the previous session.",
+  icon: { show: true, name: 'lucideIcons:info', color: 'info' },
+  actions: { confirm: { label: 'Continue', color: 'info' }, cancel: { label: 'Cancel' } },
+});
+
+// Error
+this.confirm.open({
+  title: 'Session Conflict Detected',
+  message: 'You are currently logged in on another device or devices. Click "Continue" to end those sessions and continue here.',
+  icon: { show: true, name: 'lucideIcons:circle-alert', color: 'error' },
+  actions: { confirm: { label: 'Retry', color: 'error' }, cancel: { label: 'Cancel' } },
+});
+
+// Warning
+this.confirm.open({
+  title: 'Another Device is Logged In',
+  message: 'Your account is currently active elsewhere.\n Continuing will end that session immediately.',
+  icon: { show: true, name: 'lucideIcons:triangle-alert', color: 'warning' },
+  actions: { confirm: { label: 'Continue', color: 'warning' }, cancel: { label: 'Cancel' } },
+});
+
+// Success
+this.confirm.open({
+  title: 'Session Switched Successfully',
+  message: "Your previous session has been closed. You're now logged in on this device.",
+  icon: { show: true, name: 'lucideIcons:circle-check', color: 'success' },
+  actions: { confirm: { label: 'Got it', color: 'success' }, cancel: { label: 'Close' } },
+});
+```
+
+---
+
+## DI & wiring
+
+- Service is `@Injectable({ providedIn: 'root' })` — **no** provider wiring needed in `app.config.ts`.
+- Consumers must already have `MatDialog` available via Angular Material imports (the dialog component imports `MatDialogModule` itself).
+- Lucide icons require `provideIcons()` to be called once at bootstrap — already present in `apps/web/admin-portal/src/app/app.config.ts:34`.
+
+## Verification
+
+```bash
+pnpm build:web-admin
+```
+Passed ✓ — the confirmation lib compiles clean against Angular 21 and the admin portal build.
+
+End-to-end smoke test: inject `ConfirmationService` into any page component, wire a button to `.open({...}).afterClosed().subscribe(...)` for each of the four variants, and confirm visual parity with the Figma frame.

--- a/docs/plans/loading-bar.md
+++ b/docs/plans/loading-bar.md
@@ -1,0 +1,141 @@
+# Plan: Loading Bar Service + Interceptor (`@whizard/shared-ui`)
+
+## Context
+
+The admin portal currently has no global progress indicator for in-flight HTTP requests. Users get no visual feedback when the app is waiting on the API (list fetches, saves, uploads). We need a thin top-of-viewport progress bar that shows automatically for every outgoing HTTP call and hides once all in-flight requests finish.
+
+Exploration confirmed no existing loading-bar implementation in `libs/shared/ui` — building from scratch, signal-based, aligned with the repo's Angular 19 + standalone component conventions (see `ToasterService` at `libs/shared/ui/src/toaster/toaster.service.ts`).
+
+## Approach
+
+Three pieces, all under `libs/shared/ui/src/loading/`:
+
+1. **`LoadingService`** — signal-based state holder. Tracks a `Map<url, true>` of in-flight requests. When size > 0 → `show = true`; when size drops to 0 → `show = false`. Also exposes manual `show()` / `hide()` / `setAutoMode()` / `setMode()` / `setProgress()` for callers that want to drive the bar directly (e.g. a long-running non-HTTP task).
+2. **`loadingInterceptor`** — functional `HttpInterceptorFn`. On request: `_setLoadingStatus(true, req.url)`. On `finalize` (success or error): `_setLoadingStatus(false, req.url)`. Bypasses if `auto$` is `false`.
+3. **`LoadingBarComponent`** — presentational. Reads `show$` / `mode$` / `progress$` signals. Renders a fixed, 3px-tall bar at the top of its container (positioned by the layout). Uses Angular Material's `MatProgressBar` under the hood so determinate/indeterminate modes come for free, themed to the WRCF `accent` (`#00BFFF`) color.
+
+### Architecture
+
+```
+HTTP request ──► loadingInterceptor ──► LoadingService
+                                              │ signal<boolean> show$
+                                              ▼
+                                       LoadingBarComponent
+                                       (mounted in AdminLayoutComponent)
+```
+
+Key decisions:
+
+- **Signals over RxJS**: matches `ToasterService` / `PageActionsService` convention. Fuse uses `BehaviorSubject`; we translate to `signal<T>`.
+- **Functional interceptor** (`HttpInterceptorFn`), not class-based — matches the existing `authInterceptor` (`apps/web/admin-portal/src/app/core/interceptors/auth.interceptor.ts`) and plugs into `withInterceptors([...])`.
+- **Map keyed by URL, not request id**: mirrors Fuse. Two parallel requests to the same URL collapse into one map entry — acceptable because both finish before `show` flips off (the second `delete` is a no-op, but the interceptor only calls `_setLoadingStatus(false)` after both responses finalize). In practice, the same URL fired twice in parallel is rare; if it becomes a problem, switch to a counter per URL.
+- **Mount point**: inside `AdminLayoutComponent` template, absolutely positioned at the top of `<mat-sidenav-content>` (above the top bar). One instance per app — every portal that uses the shared layout gets it for free.
+- **Auto mode on by default**: `auto$ = true`. Pages that want to opt out of auto-handling for a specific flow can call `loadingService.setAutoMode(false)` temporarily.
+- **Standalone component**, `ChangeDetectionStrategy.OnPush`, no module wiring.
+
+### Public API
+
+```ts
+type LoadingMode = 'determinate' | 'indeterminate';
+
+class LoadingService {
+  readonly show$: Signal<boolean>;
+  readonly mode$: Signal<LoadingMode>;
+  readonly progress$: Signal<number>;
+  readonly auto$: Signal<boolean>;
+
+  show(): void;
+  hide(): void;
+  setAutoMode(value: boolean): void;
+  setMode(value: LoadingMode): void;
+  setProgress(value: number): void; // 0–100
+
+  /** Used by the interceptor — prefix with _ to signal "internal". */
+  _setLoadingStatus(status: boolean, url: string): void;
+}
+
+export const loadingInterceptor: HttpInterceptorFn;
+
+@Component({ selector: 'whizard-loading-bar', standalone: true, ... })
+export class LoadingBarComponent { /* reads service signals */ }
+```
+
+Usage from any component (optional — auto mode handles most cases):
+
+```ts
+private readonly loading = inject(LoadingService);
+// Manual control for a long non-HTTP task:
+this.loading.setMode('determinate');
+this.loading.show();
+this.loading.setProgress(42);
+this.loading.hide();
+```
+
+## Files to create
+
+All under `libs/shared/ui/src/loading/`:
+
+| File                         | Purpose                                                                      |
+| ---------------------------- | ---------------------------------------------------------------------------- |
+| `loading.service.ts`       | `LoadingService` with `signal`-backed state + URL map                    |
+| `loading.interceptor.ts`   | `loadingInterceptor: HttpInterceptorFn` — toggles status via `finalize` |
+| `loading-bar.component.ts` | Presentational bar, reads service signals, wraps `MatProgressBar`          |
+| `index.ts`                 | Barrel for the loading folder                                                |
+
+## Files to modify
+
+1. **`libs/shared/ui/src/index.ts`** — add exports:
+
+   ```ts
+   export { LoadingService } from './loading/loading.service.js';
+   export type { LoadingMode } from './loading/loading.service.js';
+   export { loadingInterceptor } from './loading/loading.interceptor.js';
+   export { LoadingBarComponent } from './loading/loading-bar.component.js';
+   ```
+
+   (`.js` extension to match existing barrel convention.)
+2. **`libs/shared/ui/src/layout/layout.component.ts`** — import `LoadingBarComponent`, add it to the `imports` array, and drop `<whizard-loading-bar />` inside `<mat-sidenav-content>` as the first child so it pins to the top of the content area (above the 64px top bar).
+3. **`apps/web/admin-portal/src/app/app.config.ts`** — add `loadingInterceptor` to the interceptor chain:
+
+   ```ts
+   import { loadingInterceptor } from '@whizard/shared-ui';
+   // ...
+   provideHttpClient(withInterceptors([authInterceptor, loadingInterceptor])),
+   ```
+
+   Order doesn't matter for correctness (both are independent), but placing `loadingInterceptor` last means its `finalize` fires after the auth header has been attached — closer to actual network completion.
+
+## Styling notes
+
+- Bar height: 3px, full width of `<mat-sidenav-content>`, positioned at top via absolute positioning inside a `position: relative` wrapper — or simply `position: sticky; top: 0; z-index: 50`.
+- Color: WRCF `accent` (`#00BFFF`) for the fill, transparent track. Override `MatProgressBar` via `::ng-deep` scoped to the component (or CSS custom properties on `.mat-mdc-progress-bar`).
+- Visibility: `@if (loading.show$()) { <mat-progress-bar ... /> }` — simple conditional, no fade animation in v1.
+- Indeterminate mode by default; determinate only when a caller opts in via `setMode('determinate')` + `setProgress(...)`.
+
+## Verification
+
+1. **Type check / build**
+   ```bash
+   pnpm build:web-admin
+   ```
+2. **Runtime smoke test** — start the admin portal:
+   ```bash
+   pnpm start:web-admin
+   ```
+
+   Navigate to any list page that fetches data (e.g. manage-internship). Confirm:- Bar appears at the top of the content area as soon as the request fires.
+   - Bar disappears once all in-flight requests finish.
+   - Firing two parallel requests keeps the bar visible until the last one finishes.
+   - A failed request (throw/4xx/5xx) still hides the bar (`finalize` guarantees it).
+   - Auto mode off (`loadingService.setAutoMode(false)`) → bar no longer auto-triggers on requests.
+3. **Lint**
+   ```bash
+   pnpm lint
+   ```
+
+## Out of scope
+
+- Per-page / scoped loading bars (only a single global bar).
+- Excluding specific URLs from auto-tracking (e.g. polling endpoints that would keep the bar permanently visible). If this becomes a need, add an `excludeUrls: RegExp[]` setter on the service and check it in the interceptor.
+- Fade-in / fade-out animation.
+- Progress reporting from `HttpEventType.UploadProgress` / `DownloadProgress` — determinate mode stays manual in v1.

--- a/docs/plans/toaster.md
+++ b/docs/plans/toaster.md
@@ -1,0 +1,142 @@
+# Plan: Toaster Service + Component (`@whizard/shared-ui`)
+
+## Context
+
+The admin portal currently has no way for components to surface transient feedback messages (success, error, warning, info). We need a reusable, injectable toaster service that any component can call (e.g. `toaster.showSuccess('Changes saved')`) and have the corresponding toast render on screen. The visual spec comes from Figma node `3116:89457` (Latest Whizard Web Design System → Toast Component), which defines four variants:
+
+| Variant | BG        | Border/Icon | Icon  |
+|---------|-----------|-------------|-------|
+| Error   | `#ffcfcf` | `#f04349`   | ⚠     |
+| Success | `#cfffd0` | `#01e17b`   | ✓     |
+| Warning | `#feffcf` | `#fdcd0f`   | i     |
+| Info    | `#cfdcff` | `#4b85f5`   | i     |
+
+Each toast: 400×50px, `border-radius: 12px`, shadow `0 16px 20px -8px rgba(3,5,18,.1)`, 16/12px padding, 12px gap, 32px icon container (inner 24px colored rounded square with a 24px white glyph), body text `#28292a` Red Hat Display, and a close (×) affordance.
+
+Exploration confirmed **no existing toast/snackbar implementation** in the repo — building from scratch.
+
+## Approach
+
+Build a **signal-based `ToasterService`** plus a single **`ToasterContainerComponent`** mounted once at the app layout root. The container observes the service's `toasts` signal and renders one `ToastComponent` per active toast. Both live in `libs/shared/ui` so every portal (admin/company/student/college) can reuse them.
+
+### Architecture
+
+```
+ToasterService  ──(signal<Toast[]>)──►  ToasterContainerComponent
+       ▲                                         │
+       │ show*()                                 │ @for
+  any component                            ToastComponent (variant)
+```
+
+Key decisions:
+
+- **State container**: `signal<Toast[]>([])` in the service — matches the convention used by `PageActionsService` (`libs/shared/ui/src/layout/page-actions.service.ts:11-22`). No RxJS needed.
+- **DI style**: `@Injectable({ providedIn: 'root' })` → tree-shakeable singleton, no manual provider wiring in `app.config.ts`.
+- **Mount point**: render `<whizard-toaster-container>` exactly once inside `AdminLayoutComponent` template (`libs/shared/ui/src/layout/layout.component.ts`) as a fixed-position overlay (top-right, `z-index: 9999`). Every portal that already uses `AdminLayoutComponent` gets toasts for free.
+- **Standalone components**: Angular 21, `standalone: true` — consistent with the rest of the repo.
+- **Auto-dismiss**: default 4000ms, cancellable by passing `{ duration: 0 }` (persistent) or a custom duration. Implemented with `setTimeout` stored on the toast record so `dismiss(id)` can clear it.
+- **Dismissal**: close button calls `toasterService.dismiss(id)`; service mutates the signal by filtering out the id.
+- **Unique ids**: incrementing counter inside the service — sufficient for UI keys.
+
+### Public API
+
+```ts
+interface ToastOptions {
+  duration?: number;         // ms, default 4000, 0 = persistent
+  dismissible?: boolean;     // default true — shows close X
+}
+
+type ToastVariant = 'success' | 'error' | 'warning' | 'info';
+
+interface Toast {
+  id: number;
+  variant: ToastVariant;
+  message: string;
+  dismissible: boolean;
+}
+
+class ToasterService {
+  readonly toasts: Signal<readonly Toast[]>;
+  show(message: string, variant: ToastVariant, options?: ToastOptions): number;
+  showSuccess(message: string, options?: ToastOptions): number;
+  showError(message: string, options?: ToastOptions): number;
+  showWarning(message: string, options?: ToastOptions): number;
+  showInfo(message: string, options?: ToastOptions): number;
+  dismiss(id: number): void;
+  clear(): void;
+}
+```
+
+Usage from any component:
+
+```ts
+private readonly toaster = inject(ToasterService);
+// ...
+this.toaster.showSuccess('Changes saved successfully.');
+this.toaster.showError('Failed to save changes. Please try again.');
+```
+
+## Files to create
+
+All under `libs/shared/ui/src/toaster/`:
+
+| File | Purpose |
+|---|---|
+| `toaster.types.ts` | `Toast`, `ToastVariant`, `ToastOptions` interfaces |
+| `toaster.service.ts` | `ToasterService` with `signal<Toast[]>` + show/dismiss/clear |
+| `toast.component.ts` | Presentational single toast (inputs: `toast`, output: `dismiss`) — implements Figma variant styling |
+| `toaster-container.component.ts` | Fixed overlay, `@for` over `toasterService.toasts()` |
+| `index.ts` | Barrel for the toaster folder |
+
+## Files to modify
+
+1. **`libs/shared/ui/src/index.ts`** — add exports:
+   ```ts
+   export { ToasterService } from './toaster/toaster.service.js';
+   export { ToasterContainerComponent } from './toaster/toaster-container.component.js';
+   export { ToastComponent } from './toaster/toast.component.js';
+   export type { Toast, ToastVariant, ToastOptions } from './toaster/toaster.types.js';
+   ```
+   (Keep the `.js` extension to match the existing barrel convention.)
+
+2. **`libs/shared/ui/src/layout/layout.component.ts`** — add `<whizard-toaster-container />` to the template root and include `ToasterContainerComponent` in the `imports` array. No changes to `app.config.ts` since the service is `providedIn: 'root'`.
+
+## Styling notes
+
+- Use the existing WRCF token stack (`libs/shared/theme/src/styles/tailwind/theme.css`) for font family (`--font-*` → Red Hat Display) and text sizing. The four semantic background / border hexes from Figma are toast-specific, not in the global token system — declare them as CSS custom properties scoped to the toast element so they don't leak:
+  ```scss
+  .whizard-toast--success { --toast-bg: #cfffd0; --toast-border: #01e17b; }
+  .whizard-toast--error   { --toast-bg: #ffcfcf; --toast-border: #f04349; }
+  .whizard-toast--warning { --toast-bg: #feffcf; --toast-border: #fdcd0f; }
+  .whizard-toast--info    { --toast-bg: #cfdcff; --toast-border: #4b85f5; }
+  ```
+- Container positioning: `position: fixed; top: 24px; right: 24px; display: flex; flex-direction: column; gap: 12px; z-index: 9999; pointer-events: none;` — each toast re-enables `pointer-events: auto`.
+- Icons: lucide set via `@whizard/icons` (`lucideIcons` namespace) — `circle-check`, `circle-alert`, `triangle-alert`, `info`, `x`.
+- Enter animation: simple `transform: translateX(100%) → 0` + `opacity 0 → 1` over 180ms. Exit: reverse. CSS-only (no Angular animations module).
+
+## Verification
+
+1. **Type check / build**
+   ```bash
+   pnpm build:web-admin
+   ```
+2. **Runtime smoke test** — start the admin portal:
+   ```bash
+   pnpm start:web-admin
+   ```
+   In any existing page component, temporarily wire a button to call each of `showSuccess`, `showError`, `showWarning`, `showInfo` and confirm:
+   - Visual parity with Figma (colors, radius, shadow, icon square, typography).
+   - Stacking: firing multiple toasts stacks them top-to-bottom with 12px gap.
+   - Auto-dismiss after 4s; close button dismisses immediately; `duration: 0` persists.
+   - No console errors; service is injectable without extra providers in `app.config.ts`.
+3. **Lint**
+   ```bash
+   pnpm lint
+   ```
+4. Revert the temporary test wiring before committing.
+
+## Out of scope
+
+- Action buttons inside toasts (e.g. "Undo") — can be added later as an optional `action?: { label; handler }` field.
+- Accessibility roles beyond `role="status"` / `aria-live="polite"` on the container.
+- i18n of default messages — callers always pass their own strings.

--- a/libs/shared/ui/src/confirmation/confirmation.service.ts
+++ b/libs/shared/ui/src/confirmation/confirmation.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, inject } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { ConfirmationDialogResult, WhizardConfirmationConfig } from './confirmation.types.js';
+import { ConfirmationDialogComponent } from './dialog/confirmation-dialog.component.js';
+
+@Injectable({ providedIn: 'root' })
+export class ConfirmationService {
+  private readonly matDialog = inject(MatDialog);
+
+  private readonly defaultConfig: WhizardConfirmationConfig = {
+    title: 'Confirm action',
+    message: 'Are you sure you want to confirm this action?',
+    icon: {
+      show: true,
+      name: 'lucideIcons:triangle-alert',
+      color: 'warning',
+    },
+    actions: {
+      confirm: {
+        show: true,
+        label: 'Confirm',
+        color: 'error',
+      },
+      cancel: {
+        show: true,
+        label: 'Cancel',
+      },
+    },
+    dismissible: false,
+  };
+
+  open(
+    config: WhizardConfirmationConfig = {},
+  ): MatDialogRef<ConfirmationDialogComponent, ConfirmationDialogResult> {
+    const merged: WhizardConfirmationConfig = {
+      ...this.defaultConfig,
+      ...config,
+      icon: { ...this.defaultConfig.icon, ...config.icon },
+      actions: {
+        confirm: {
+          ...this.defaultConfig.actions?.confirm,
+          ...config.actions?.confirm,
+        },
+        cancel: {
+          ...this.defaultConfig.actions?.cancel,
+          ...config.actions?.cancel,
+        },
+      },
+    };
+
+    return this.matDialog.open<ConfirmationDialogComponent, WhizardConfirmationConfig, ConfirmationDialogResult>(
+      ConfirmationDialogComponent,
+      {
+        autoFocus: false,
+        disableClose: !merged.dismissible,
+        data: merged,
+        panelClass: 'whizard-confirmation-dialog-panel',
+      },
+    );
+  }
+}

--- a/libs/shared/ui/src/confirmation/confirmation.types.ts
+++ b/libs/shared/ui/src/confirmation/confirmation.types.ts
@@ -1,0 +1,42 @@
+export type ConfirmationIconColor =
+  | 'primary'
+  | 'accent'
+  | 'warn'
+  | 'basic'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'error';
+
+export type ConfirmationActionColor =
+  | 'primary'
+  | 'accent'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'warn';
+
+export interface WhizardConfirmationConfig {
+  title?: string;
+  message?: string;
+  icon?: {
+    show?: boolean;
+    name?: string;
+    color?: ConfirmationIconColor;
+  };
+  actions?: {
+    confirm?: {
+      show?: boolean;
+      label?: string;
+      color?: ConfirmationActionColor;
+    };
+    cancel?: {
+      show?: boolean;
+      label?: string;
+    };
+  };
+  dismissible?: boolean;
+}
+
+export type ConfirmationDialogResult = 'confirmed' | 'cancelled' | undefined;

--- a/libs/shared/ui/src/confirmation/dialog/confirmation-dialog.component.html
+++ b/libs/shared/ui/src/confirmation/dialog/confirmation-dialog.component.html
@@ -1,0 +1,53 @@
+<div class="whizard-confirmation">
+  <div class="whizard-confirmation__header">
+    @if (data.icon?.show && data.icon?.name) {
+      <div
+        class="whizard-confirmation__icon"
+        [attr.data-color]="data.icon?.color ?? 'info'">
+        <mat-icon [svgIcon]="data.icon!.name!" />
+      </div>
+    }
+
+    @if (data.title) {
+      <h2 class="whizard-confirmation__title" [innerHTML]="data.title"></h2>
+    }
+
+    @if (data.dismissible) {
+      <button
+        type="button"
+        class="whizard-confirmation__close"
+        [matDialogClose]="undefined"
+        aria-label="Close dialog">
+        <mat-icon svgIcon="lucideIcons:x" />
+      </button>
+    }
+  </div>
+
+  @if (data.message) {
+    <div class="whizard-confirmation__body">
+      <p class="whizard-confirmation__message" [innerHTML]="data.message"></p>
+    </div>
+  }
+
+  @if (data.actions?.confirm?.show || data.actions?.cancel?.show) {
+    <div class="whizard-confirmation__actions">
+      @if (data.actions?.cancel?.show) {
+        <button
+          type="button"
+          class="whizard-confirmation__btn whizard-confirmation__btn--cancel"
+          [matDialogClose]="'cancelled'">
+          {{ data.actions?.cancel?.label }}
+        </button>
+      }
+      @if (data.actions?.confirm?.show) {
+        <button
+          type="button"
+          class="whizard-confirmation__btn whizard-confirmation__btn--confirm"
+          [attr.data-color]="data.actions?.confirm?.color ?? 'info'"
+          [matDialogClose]="'confirmed'">
+          {{ data.actions?.confirm?.label }}
+        </button>
+      }
+    </div>
+  }
+</div>

--- a/libs/shared/ui/src/confirmation/dialog/confirmation-dialog.component.ts
+++ b/libs/shared/ui/src/confirmation/dialog/confirmation-dialog.component.ts
@@ -1,0 +1,211 @@
+import { Component, inject, ViewEncapsulation } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { WhizardConfirmationConfig } from '../confirmation.types.js';
+
+@Component({
+  selector: 'whizard-confirmation-dialog',
+  standalone: true,
+  imports: [MatDialogModule, MatIconModule],
+  templateUrl: './confirmation-dialog.component.html',
+  styles: [`
+    .whizard-confirmation-dialog-panel .mat-mdc-dialog-surface {
+      background: transparent !important;
+      box-shadow: none !important;
+      border-radius: 16px !important;
+      padding: 0 !important;
+      overflow: hidden;
+    }
+    .whizard-confirmation-dialog-panel .mat-mdc-dialog-container {
+      --mdc-dialog-container-color: transparent;
+      padding: 0 !important;
+    }
+
+    .whizard-confirmation {
+      display: flex;
+      flex-direction: column;
+      width: 499px;
+      max-width: 100%;
+      background: rgba(30, 41, 59, 0.94);
+      backdrop-filter: blur(8px);
+      border-radius: 16px;
+      box-shadow: 0 8px 36px 0 rgba(0, 0, 0, 0.16);
+      font-family: 'Red Hat Display', system-ui, sans-serif;
+      overflow: hidden;
+    }
+
+    .whizard-confirmation__header {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 24px 24px 0;
+      position: relative;
+    }
+
+    .whizard-confirmation__icon {
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 40px;
+      height: 40px;
+      border-radius: 9999px;
+      background: rgba(0, 132, 255, 0.1);
+      color: #0084ff;
+    }
+    .whizard-confirmation__icon mat-icon {
+      width: 24px;
+      height: 24px;
+      font-size: 24px;
+      line-height: 24px;
+    }
+    .whizard-confirmation__icon[data-color="primary"],
+    .whizard-confirmation__icon[data-color="info"] {
+      background: rgba(0, 132, 255, 0.1);
+      color: #0084ff;
+    }
+    .whizard-confirmation__icon[data-color="accent"] {
+      background: rgba(49, 77, 223, 0.12);
+      color: #314ddf;
+    }
+    .whizard-confirmation__icon[data-color="success"] {
+      background: rgba(1, 225, 123, 0.1);
+      color: #01e17b;
+    }
+    .whizard-confirmation__icon[data-color="warning"] {
+      background: rgba(253, 205, 15, 0.12);
+      color: #fdcd0f;
+    }
+    .whizard-confirmation__icon[data-color="error"],
+    .whizard-confirmation__icon[data-color="warn"] {
+      background: rgba(240, 67, 73, 0.1);
+      color: #f04349;
+    }
+    .whizard-confirmation__icon[data-color="basic"] {
+      background: rgba(127, 148, 174, 0.12);
+      color: #7f94ae;
+    }
+
+    .whizard-confirmation__title {
+      margin: 0;
+      flex: 1 1 auto;
+      min-width: 0;
+      font-family: 'Red Hat Display', system-ui, sans-serif;
+      font-size: 19px;
+      font-weight: 700;
+      line-height: 24px;
+      color: #e8f0fa;
+    }
+
+    .whizard-confirmation__close {
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+      border: none;
+      background: transparent;
+      color: #7f94ae;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: background 120ms ease, color 120ms ease;
+    }
+    .whizard-confirmation__close:hover {
+      background: rgba(127, 148, 174, 0.12);
+      color: #e8f0fa;
+    }
+    .whizard-confirmation__close mat-icon {
+      width: 20px;
+      height: 20px;
+      font-size: 20px;
+    }
+
+    .whizard-confirmation__body {
+      padding: 10px 24px 20px 76px;
+    }
+    .whizard-confirmation__message {
+      margin: 0;
+      font-size: 14px;
+      font-weight: 400;
+      line-height: 20px;
+      color: #7f94ae;
+      white-space: pre-wrap;
+    }
+
+    .whizard-confirmation__actions {
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 8px;
+      height: 60px;
+      padding: 15px;
+      background: rgba(15, 23, 42, 0.6);
+      border-top: 1px solid rgba(72, 78, 93, 0.6);
+    }
+
+    .whizard-confirmation__btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      height: 42px;
+      min-width: 100px;
+      padding: 0 16px;
+      border-radius: 8px;
+      font-family: 'Red Hat Display', system-ui, sans-serif;
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 24px;
+      cursor: pointer;
+      transition: background 120ms ease, border-color 120ms ease, filter 120ms ease;
+      white-space: nowrap;
+    }
+
+    .whizard-confirmation__btn--cancel {
+      background: transparent;
+      color: #ffffff;
+      border: 1px solid #484e5d;
+    }
+    .whizard-confirmation__btn--cancel:hover {
+      background: rgba(72, 78, 93, 0.25);
+      border-color: #7f94ae;
+    }
+
+    .whizard-confirmation__btn--confirm {
+      border: none;
+      color: #ffffff;
+      background: #314ddf;
+    }
+    .whizard-confirmation__btn--confirm:hover {
+      filter: brightness(1.08);
+    }
+    .whizard-confirmation__btn--confirm[data-color="primary"],
+    .whizard-confirmation__btn--confirm[data-color="info"] {
+      background: #314ddf;
+    }
+    .whizard-confirmation__btn--confirm[data-color="accent"] {
+      background: #00bfff;
+      color: #0f172a;
+    }
+    .whizard-confirmation__btn--confirm[data-color="success"] {
+      background: #28a745;
+    }
+    .whizard-confirmation__btn--confirm[data-color="warning"] {
+      background: #ffa500;
+    }
+    .whizard-confirmation__btn--confirm[data-color="error"],
+    .whizard-confirmation__btn--confirm[data-color="warn"] {
+      background: #f04349;
+    }
+
+    @media (max-width: 560px) {
+      .whizard-confirmation { width: 100%; }
+      .whizard-confirmation__body { padding-left: 24px; }
+    }
+  `],
+  encapsulation: ViewEncapsulation.None,
+})
+export class ConfirmationDialogComponent {
+  readonly data: WhizardConfirmationConfig = inject(MAT_DIALOG_DATA);
+  readonly matDialogRef = inject(MatDialogRef<ConfirmationDialogComponent>);
+}

--- a/libs/shared/ui/src/confirmation/index.ts
+++ b/libs/shared/ui/src/confirmation/index.ts
@@ -1,0 +1,8 @@
+export { ConfirmationService } from './confirmation.service.js';
+export { ConfirmationDialogComponent } from './dialog/confirmation-dialog.component.js';
+export type {
+  WhizardConfirmationConfig,
+  ConfirmationIconColor,
+  ConfirmationActionColor,
+  ConfirmationDialogResult,
+} from './confirmation.types.js';

--- a/libs/shared/ui/src/index.ts
+++ b/libs/shared/ui/src/index.ts
@@ -29,6 +29,28 @@ export type { ImageLightboxDialogData } from './image-lightbox/image-lightbox.co
 export { MediaUploaderComponent } from './media-uploader/media-uploader.component.js';
 export type { UploadedFile } from './media-uploader/media-uploader.component.js';
 
+// Toaster
+export { ToasterService } from './toaster/toaster.service.js';
+export { ToastComponent } from './toaster/toast.component.js';
+export { ToasterContainerComponent } from './toaster/toaster-container.component.js';
+export type { Toast, ToastVariant, ToastOptions } from './toaster/toaster.types.js';
+
+// Confirmation dialog
+export { ConfirmationService } from './confirmation/confirmation.service.js';
+export { ConfirmationDialogComponent } from './confirmation/dialog/confirmation-dialog.component.js';
+export type {
+  WhizardConfirmationConfig,
+  ConfirmationIconColor,
+  ConfirmationActionColor,
+  ConfirmationDialogResult,
+} from './confirmation/confirmation.types.js';
+
+// Loading bar
+export { LoadingService } from './loading/loading.service.js';
+export type { LoadingMode } from './loading/loading.service.js';
+export { loadingInterceptor } from './loading/loading.interceptor.js';
+export { LoadingBarComponent } from './loading/loading-bar.component.js';
+
 // Signed URL pipe
 export { SignedUrlPipe } from './signed-url/signed-url.pipe.js';
 export { SIGNED_URL_PROVIDER } from './signed-url/signed-url.token.js';

--- a/libs/shared/ui/src/layout/layout.component.ts
+++ b/libs/shared/ui/src/layout/layout.component.ts
@@ -20,6 +20,8 @@ import {
 } from '@angular/router';
 import { filter, map } from 'rxjs';
 import { ScrollbarDirective } from '../directives/scrollbar/scrollbar.directive';
+import { LoadingBarComponent } from '../loading/loading-bar.component';
+import { ToasterContainerComponent } from '../toaster/toaster-container.component';
 import { LAYOUT_AUTH_SERVICE, LAYOUT_TENANT_SERVICE } from './auth.token';
 import { AdminFooterComponent } from './footer.component';
 import { PageActionsService } from './page-actions.service';
@@ -47,6 +49,8 @@ import { AdminSidebarComponent } from './sidebar.component';
     // NotificationsComponent,
     MatButtonModule,
     ScrollbarDirective,
+    ToasterContainerComponent,
+    LoadingBarComponent,
   ],
   template: `
     <mat-sidenav-container>
@@ -70,8 +74,10 @@ import { AdminSidebarComponent } from './sidebar.component';
 
       <mat-sidenav-content
         class="flex flex-col overflow-hidden dark:border-neutral-800 dark:bg-primary-950"
-        style="height: 100vh;"
+        style="height: 100vh; position: relative;"
       >
+        <whizard-loading-bar />
+
         <!-- Top bar — always visible -->
         <div
           class="flex items-center h-16 px-4 shrink-0 gap-x-3"
@@ -167,6 +173,8 @@ import { AdminSidebarComponent } from './sidebar.component';
         <whizard-admin-footer />
       </mat-sidenav-content>
     </mat-sidenav-container>
+
+    <whizard-toaster-container />
 
     <mat-menu #topbarUserMenu="matMenu">
       <button mat-menu-item routerLink="/profile">

--- a/libs/shared/ui/src/loading/index.ts
+++ b/libs/shared/ui/src/loading/index.ts
@@ -1,0 +1,4 @@
+export { LoadingService } from './loading.service.js';
+export type { LoadingMode } from './loading.service.js';
+export { loadingInterceptor } from './loading.interceptor.js';
+export { LoadingBarComponent } from './loading-bar.component.js';

--- a/libs/shared/ui/src/loading/loading-bar.component.ts
+++ b/libs/shared/ui/src/loading/loading-bar.component.ts
@@ -1,0 +1,55 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewEncapsulation,
+  inject,
+} from '@angular/core';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { LoadingService } from './loading.service.js';
+
+@Component({
+  selector: 'whizard-loading-bar',
+  standalone: true,
+  imports: [MatProgressBarModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (loading.show$()) {
+      <mat-progress-bar
+        class="whizard-loading-bar__bar"
+        [mode]="loading.mode$()"
+        [value]="loading.progress$()"
+      />
+    }
+  `,
+  styles: [
+    `
+      whizard-loading-bar {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        z-index: 50;
+        pointer-events: none;
+        display: block;
+      }
+
+      whizard-loading-bar .whizard-loading-bar__bar {
+        height: 3px;
+      }
+
+      whizard-loading-bar .whizard-loading-bar__bar .mdc-linear-progress__buffer-bar {
+        background-color: transparent;
+      }
+
+      whizard-loading-bar
+        .whizard-loading-bar__bar
+        .mdc-linear-progress__bar-inner {
+        border-color: #00bfff;
+      }
+    `,
+  ],
+  encapsulation: ViewEncapsulation.None,
+})
+export class LoadingBarComponent {
+  readonly loading = inject(LoadingService);
+}

--- a/libs/shared/ui/src/loading/loading.interceptor.ts
+++ b/libs/shared/ui/src/loading/loading.interceptor.ts
@@ -1,0 +1,20 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { finalize } from 'rxjs';
+import { LoadingService } from './loading.service.js';
+
+export const loadingInterceptor: HttpInterceptorFn = (req, next) => {
+  const loadingService = inject(LoadingService);
+
+  if (!loadingService.auto$()) {
+    return next(req);
+  }
+
+  loadingService._setLoadingStatus(true, req.url);
+
+  return next(req).pipe(
+    finalize(() => {
+      loadingService._setLoadingStatus(false, req.url);
+    }),
+  );
+};

--- a/libs/shared/ui/src/loading/loading.service.ts
+++ b/libs/shared/ui/src/loading/loading.service.ts
@@ -1,0 +1,59 @@
+import { Injectable, Signal, signal } from '@angular/core';
+
+export type LoadingMode = 'determinate' | 'indeterminate';
+
+@Injectable({ providedIn: 'root' })
+export class LoadingService {
+  private readonly _show = signal<boolean>(false);
+  private readonly _mode = signal<LoadingMode>('indeterminate');
+  private readonly _progress = signal<number>(0);
+  private readonly _auto = signal<boolean>(true);
+  private readonly urlMap = new Map<string, boolean>();
+
+  readonly show$: Signal<boolean> = this._show.asReadonly();
+  readonly mode$: Signal<LoadingMode> = this._mode.asReadonly();
+  readonly progress$: Signal<number> = this._progress.asReadonly();
+  readonly auto$: Signal<boolean> = this._auto.asReadonly();
+
+  show(): void {
+    this._show.set(true);
+  }
+
+  hide(): void {
+    this._show.set(false);
+  }
+
+  setAutoMode(value: boolean): void {
+    this._auto.set(value);
+  }
+
+  setMode(value: LoadingMode): void {
+    this._mode.set(value);
+  }
+
+  setProgress(value: number): void {
+    if (value < 0 || value > 100) {
+      console.error('Progress value must be between 0 and 100!');
+      return;
+    }
+    this._progress.set(value);
+  }
+
+  _setLoadingStatus(status: boolean, url: string): void {
+    if (!url) {
+      console.error('The request URL must be provided!');
+      return;
+    }
+
+    if (status) {
+      this.urlMap.set(url, true);
+      this._show.set(true);
+    } else if (this.urlMap.has(url)) {
+      this.urlMap.delete(url);
+    }
+
+    if (this.urlMap.size === 0) {
+      this._show.set(false);
+    }
+  }
+}

--- a/libs/shared/ui/src/toaster/index.ts
+++ b/libs/shared/ui/src/toaster/index.ts
@@ -1,0 +1,4 @@
+export { ToasterService } from './toaster.service.js';
+export { ToastComponent } from './toast.component.js';
+export { ToasterContainerComponent } from './toaster-container.component.js';
+export type { Toast, ToastVariant, ToastOptions } from './toaster.types.js';

--- a/libs/shared/ui/src/toaster/toast.component.ts
+++ b/libs/shared/ui/src/toaster/toast.component.ts
@@ -1,0 +1,142 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { Toast, ToastVariant } from './toaster.types.js';
+
+const ICON_BY_VARIANT: Record<ToastVariant, string> = {
+  success: 'lucideIcons:circle-check',
+  error: 'lucideIcons:circle-alert',
+  warning: 'lucideIcons:triangle-alert',
+  info: 'lucideIcons:info',
+};
+
+@Component({
+  selector: 'whizard-toast',
+  standalone: true,
+  imports: [MatIconModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="whizard-toast" [attr.data-variant]="toast.variant" role="status">
+      <div class="whizard-toast__icon">
+        <mat-icon [svgIcon]="iconName" />
+      </div>
+      <div class="whizard-toast__message">{{ toast.message }}</div>
+      @if (toast.dismissible) {
+        <button
+          type="button"
+          class="whizard-toast__close"
+          (click)="dismiss.emit(toast.id)"
+          aria-label="Dismiss notification">
+          <mat-icon svgIcon="lucideIcons:x" />
+        </button>
+      }
+    </div>
+  `,
+  styles: [`
+    :host {
+      display: block;
+      pointer-events: auto;
+      animation: whizard-toast-in 180ms ease-out both;
+    }
+
+    .whizard-toast {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      width: 400px;
+      max-width: 100%;
+      height: 50px;
+      padding: 12px 16px;
+      border-radius: 12px;
+      border: 1px solid var(--toast-border, #f04349);
+      background: var(--toast-bg, #ffcfcf);
+      box-shadow: 0 16px 20px -8px rgba(3, 5, 18, 0.1);
+      font-family: 'Red Hat Display', system-ui, sans-serif;
+      color: #28292a;
+      overflow: hidden;
+    }
+    .whizard-toast[data-variant="success"] {
+      --toast-bg: #cfffd0;
+      --toast-border: #01e17b;
+    }
+    .whizard-toast[data-variant="error"] {
+      --toast-bg: #ffcfcf;
+      --toast-border: #f04349;
+    }
+    .whizard-toast[data-variant="warning"] {
+      --toast-bg: #feffcf;
+      --toast-border: #fdcd0f;
+    }
+    .whizard-toast[data-variant="info"] {
+      --toast-bg: #cfdcff;
+      --toast-border: #4b85f5;
+    }
+
+    .whizard-toast__icon {
+      flex: 0 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+      border-radius: 6px;
+      background: var(--toast-border);
+      color: #ffffff;
+    }
+    .whizard-toast__icon mat-icon {
+      width: 16px;
+      height: 16px;
+      font-size: 16px;
+      line-height: 16px;
+      color: #ffffff;
+    }
+
+    .whizard-toast__message {
+      flex: 1 1 auto;
+      min-width: 0;
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 22px;
+      color: #28292a;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .whizard-toast__close {
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+      padding: 0;
+      border: none;
+      background: transparent;
+      color: var(--toast-border);
+      cursor: pointer;
+      border-radius: 4px;
+      transition: opacity 120ms ease;
+    }
+    .whizard-toast__close:hover { opacity: 0.75; }
+    .whizard-toast__close mat-icon {
+      width: 16px;
+      height: 16px;
+      font-size: 16px;
+      line-height: 16px;
+    }
+
+    @keyframes whizard-toast-in {
+      from { transform: translateX(16px); opacity: 0; }
+      to   { transform: translateX(0);    opacity: 1; }
+    }
+  `],
+  encapsulation: ViewEncapsulation.None,
+})
+export class ToastComponent {
+  @Input({ required: true }) toast!: Toast;
+  @Output() readonly dismiss = new EventEmitter<number>();
+
+  get iconName(): string {
+    return ICON_BY_VARIANT[this.toast.variant];
+  }
+}

--- a/libs/shared/ui/src/toaster/toaster-container.component.ts
+++ b/libs/shared/ui/src/toaster/toaster-container.component.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation, inject } from '@angular/core';
+import { ToastComponent } from './toast.component.js';
+import { ToasterService } from './toaster.service.js';
+
+@Component({
+  selector: 'whizard-toaster-container',
+  standalone: true,
+  imports: [ToastComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="whizard-toaster-container" aria-live="polite" aria-atomic="false">
+      @for (toast of toasterService.toasts(); track toast.id) {
+        <whizard-toast
+          [toast]="toast"
+          (dismiss)="toasterService.dismiss($event)" />
+      }
+    </div>
+  `,
+  styles: [`
+    .whizard-toaster-container {
+      position: fixed;
+      top: 24px;
+      right: 24px;
+      z-index: 9999;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      pointer-events: none;
+      max-width: calc(100vw - 48px);
+    }
+  `],
+  encapsulation: ViewEncapsulation.None,
+})
+export class ToasterContainerComponent {
+  readonly toasterService = inject(ToasterService);
+}

--- a/libs/shared/ui/src/toaster/toaster.service.ts
+++ b/libs/shared/ui/src/toaster/toaster.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, Signal, signal } from '@angular/core';
+import { Toast, ToastOptions, ToastVariant } from './toaster.types.js';
+
+const DEFAULT_DURATION = 4000;
+
+@Injectable({ providedIn: 'root' })
+export class ToasterService {
+  private readonly _toasts = signal<Toast[]>([]);
+  readonly toasts: Signal<readonly Toast[]> = this._toasts.asReadonly();
+
+  private nextId = 1;
+  private readonly timers = new Map<number, ReturnType<typeof setTimeout>>();
+
+  show(message: string, variant: ToastVariant, options: ToastOptions = {}): number {
+    const id = this.nextId++;
+    const toast: Toast = {
+      id,
+      variant,
+      message,
+      dismissible: options.dismissible ?? true,
+    };
+    this._toasts.update((list) => [...list, toast]);
+
+    const duration = options.duration ?? DEFAULT_DURATION;
+    if (duration > 0) {
+      const handle = setTimeout(() => this.dismiss(id), duration);
+      this.timers.set(id, handle);
+    }
+
+    return id;
+  }
+
+  showSuccess(message: string, options?: ToastOptions): number {
+    return this.show(message, 'success', options);
+  }
+
+  showError(message: string, options?: ToastOptions): number {
+    return this.show(message, 'error', options);
+  }
+
+  showWarning(message: string, options?: ToastOptions): number {
+    return this.show(message, 'warning', options);
+  }
+
+  showInfo(message: string, options?: ToastOptions): number {
+    return this.show(message, 'info', options);
+  }
+
+  dismiss(id: number): void {
+    const handle = this.timers.get(id);
+    if (handle) {
+      clearTimeout(handle);
+      this.timers.delete(id);
+    }
+    this._toasts.update((list) => list.filter((t) => t.id !== id));
+  }
+
+  clear(): void {
+    this.timers.forEach((handle) => clearTimeout(handle));
+    this.timers.clear();
+    this._toasts.set([]);
+  }
+}

--- a/libs/shared/ui/src/toaster/toaster.types.ts
+++ b/libs/shared/ui/src/toaster/toaster.types.ts
@@ -1,0 +1,15 @@
+export type ToastVariant = 'success' | 'error' | 'warning' | 'info';
+
+export interface ToastOptions {
+  /** Auto-dismiss after this many ms. Default 4000. 0 = persistent. */
+  duration?: number;
+  /** Show the close (X) affordance. Default true. */
+  dismissible?: boolean;
+}
+
+export interface Toast {
+  id: number;
+  variant: ToastVariant;
+  message: string;
+  dismissible: boolean;
+}

--- a/prisma/migrations/20260409112803_add_media_asset_metadata_fields/migration.sql
+++ b/prisma/migrations/20260409112803_add_media_asset_metadata_fields/migration.sql
@@ -1,5 +1,6 @@
 -- AlterTable
 ALTER TABLE "media_assets" ADD COLUMN     "duration" DOUBLE PRECISION,
+ADD COLUMN     "file_name" TEXT,
 ADD COLUMN     "format" TEXT,
 ADD COLUMN     "height" INTEGER,
 ADD COLUMN     "pages" INTEGER,
@@ -7,3 +8,6 @@ ADD COLUMN     "thumbnail_key" TEXT,
 ADD COLUMN     "thumbnail_xl_key" TEXT,
 ADD COLUMN     "thumbnail_xl_url" TEXT,
 ADD COLUMN     "width" INTEGER;
+
+-- CreateIndex
+CREATE INDEX "media_assets_created_by_idx" ON "media_assets"("created_by");

--- a/prisma/migrations/20260409130000_add_media_asset_file_name_and_created_by_index/migration.sql
+++ b/prisma/migrations/20260409130000_add_media_asset_file_name_and_created_by_index/migration.sql
@@ -1,5 +1,0 @@
--- AlterTable
-ALTER TABLE "media_assets" ADD COLUMN "file_name" TEXT;
-
--- CreateIndex
-CREATE INDEX "media_assets_created_by_idx" ON "media_assets"("created_by");


### PR DESCRIPTION
* Add ConfirmationService with Material dialog for confirm flows
* Add LoadingService, loading bar, and HTTP interceptor for progress
* Add ToasterService with container + toast component for notifications
* Wire new providers into admin portal app config and layout
* Apply confirmation + toaster in manage-internship pages