### PR TITLE
feat(internship): unify tenant selection header for admin scoping

### DIFF
--- a/apps/api/bff/src/modules/internship-hiring/routes.ts
+++ b/apps/api/bff/src/modules/internship-hiring/routes.ts
@@ -10,8 +10,8 @@ const buildCoreApiHeaders = (request: FastifyRequestLike): Record<string, string
   if (request.headers['authorization']) {
     headers['Authorization'] = String(request.headers['authorization']);
   }
-  if (request.headers['x-company-tenant-id']) {
-    headers['X-Company-Tenant-Id'] = String(request.headers['x-company-tenant-id']);
+  if (request.headers['x-selected-tenant-id']) {
+    headers['X-Selected-Tenant-Id'] = String(request.headers['x-selected-tenant-id']);
   }
   return headers;
 };

--- a/apps/api/core-api/src/modules/internship-hiring/routes.ts
+++ b/apps/api/core-api/src/modules/internship-hiring/routes.ts
@@ -9,13 +9,21 @@ const logger = getOrCreateAppLogger({ service: 'core-api' }).child({ component: 
 const isDomainException = (err: unknown): err is Error =>
   err instanceof Error && err.name === 'DomainException';
 
+const SYSTEM_TENANT_ID = process.env['SYSTEM_TENANT_ID'] ?? '0';
+
+// ctx.tenantId is already the effective tenant resolved from x-selected-tenant-id
+// (see getRequestContext). For a COMPANY user it is their own tenant; for a SYSTEM
+// admin it is either the selected tenant or the system tenant when nothing selected.
 const resolveCompanyTenantId = (
   ctx: ReturnType<typeof getRequestContext>,
-  request: Parameters<typeof getRequestContext>[0],
 ): string | undefined =>
-  ctx.tenantType === 'COMPANY'
-    ? ctx.tenantId
-    : ((request.headers['x-company-tenant-id'] as string | undefined) || undefined);
+  ctx.tenantId !== SYSTEM_TENANT_ID ? ctx.tenantId : undefined;
+
+// Owner tenant of an internship record — SYSTEM for admin-created, company for company-created.
+const resolveOwnerTenantId = (
+  ctx: ReturnType<typeof getRequestContext>,
+): string =>
+  ctx.tenantType === 'COMPANY' ? ctx.tenantId : SYSTEM_TENANT_ID;
 
 export const registerInternshipHiringRoutes = (
   app: FastifyInstanceLike,
@@ -30,11 +38,15 @@ export const registerInternshipHiringRoutes = (
     handler: async (request, reply) => {
       const ctx = getRequestContext(request);
       const { search, status } = (request.query as Record<string, string | undefined>);
-      const companyTenantId = resolveCompanyTenantId(ctx, request);
-      logger.debug('Listing internships', { ...getLogContext(request), userId: ctx.actorUserAccountId, tenantId: ctx.tenantId, companyTenantId });
+      const companyTenantId = resolveCompanyTenantId(ctx);
+      const ownerTenantId = resolveOwnerTenantId(ctx);
+      // SYSTEM admin with no company selected → return internships across all tenants.
+      const allTenants = ctx.tenantType === 'SYSTEM' && !companyTenantId;
+      logger.debug('Listing internships', { ...getLogContext(request), userId: ctx.actorUserAccountId, tenantId: ownerTenantId, companyTenantId, allTenants });
       const data = await deps.listInternships.execute({
-        tenantId: ctx.tenantId,
+        tenantId: ownerTenantId,
         companyTenantId,
+        allTenants,
         search,
         status,
       });
@@ -50,12 +62,13 @@ export const registerInternshipHiringRoutes = (
     handler: async (request, reply) => {
       const ctx  = getRequestContext(request);
       const body = request.body as Record<string, unknown>;
-      const companyTenantId = resolveCompanyTenantId(ctx, request);
-      logger.debug('Creating internship', { ...getLogContext(request), userId: ctx.actorUserAccountId, tenantId: ctx.tenantId, companyTenantId });
+      const companyTenantId = resolveCompanyTenantId(ctx);
+      const ownerTenantId = resolveOwnerTenantId(ctx);
+      logger.debug('Creating internship', { ...getLogContext(request), userId: ctx.actorUserAccountId, tenantId: ownerTenantId, companyTenantId });
       const data = await deps.createInternship.execute({
         ...(body as Record<string, unknown>),
         actorUserId:     ctx.actorUserAccountId,
-        tenantId:        ctx.tenantId,
+        tenantId:        ownerTenantId,
         companyTenantId: companyTenantId ?? null,
       } as never);
       reply.status(201).send({ success: true, data, meta: toApiMeta(request) });
@@ -69,7 +82,7 @@ export const registerInternshipHiringRoutes = (
     preHandler: authorizationPreHandler('INTERNSHIP.MANAGE'),
     handler: async (request, reply) => {
       const ctx = getRequestContext(request);
-      const companyTenantId = resolveCompanyTenantId(ctx, request)
+      const companyTenantId = resolveCompanyTenantId(ctx)
         ?? (request.query as Record<string, string>)['companyTenantId'];
 
       if (!companyTenantId) {
@@ -101,22 +114,33 @@ export const registerInternshipHiringRoutes = (
     },
   });
 
-  // GET /api/internships/roles — industry roles scoped to the company's tenant
+  // GET /api/internships/roles — industry roles scoped to the company's tenant.
+  // SYSTEM admin with no company selected → returns all active roles across tenants.
   app.route({
     method: 'GET',
     url: '/roles',
     preHandler: authorizationPreHandler('INTERNSHIP.MANAGE'),
     handler: async (request, reply) => {
       const ctx = getRequestContext(request);
-      const companyTenantId = resolveCompanyTenantId(ctx, request);
+      const companyTenantId = resolveCompanyTenantId(ctx);
+      const prisma = getPrisma();
 
       if (!companyTenantId) {
-        return reply
-          .status(400)
-          .send({ success: false, error: 'companyTenantId is required' });
+        if (ctx.tenantType !== 'SYSTEM') {
+          return reply
+            .status(400)
+            .send({ success: false, error: 'companyTenantId is required' });
+        }
+
+        const roles = await prisma.role.findMany({
+          where: { isActive: true },
+          orderBy: { name: 'asc' },
+          select: { publicUuid: true, name: true },
+        });
+        const data = roles.map(r => ({ id: r.publicUuid, name: r.name }));
+        return reply.status(200).send({ success: true, data, meta: toApiMeta(request) });
       }
 
-      const prisma = getPrisma();
       const company = await prisma.company.findFirst({
         where: { tenantId: BigInt(companyTenantId) },
         select: { industryId: true },
@@ -129,16 +153,20 @@ export const registerInternshipHiringRoutes = (
       }
 
       const roles = await prisma.role.findMany({
-        where: { industryId: company.industryId, tenantId: BigInt(companyTenantId), isActive: true },
+        where: {
+          industryId: company.industryId,
+          tenantId: BigInt(companyTenantId),
+          isActive: true,
+        },
         orderBy: { name: 'asc' },
-        select: { publicUuid: true, name: true , id: true},
+        select: { publicUuid: true, name: true, id: true },
       });
 
       const data = roles.map((r: { publicUuid: string; name: string }) => ({
         id: r.publicUuid,
         name: r.name,
       }));
-      reply.status(200).send({ success: true, data, meta: toApiMeta(request) });
+      reply.status(200).send({ success: true, data, meta: toApiMeta(request), companyTenantId });
     },
   });
 
@@ -149,7 +177,7 @@ export const registerInternshipHiringRoutes = (
     preHandler: authorizationPreHandler('INTERNSHIP.MANAGE'),
     handler: async (request, reply) => {
       const ctx = getRequestContext(request);
-      const companyTenantId = resolveCompanyTenantId(ctx, request);
+      const companyTenantId = resolveCompanyTenantId(ctx);
       const { roleId } = (request.query as Record<string, string | undefined>);
 
       if (!companyTenantId) {
@@ -208,7 +236,7 @@ export const registerInternshipHiringRoutes = (
       const fgs = await prisma.functionalGroup.findMany({
         where: {
           industryId: company.industryId,
-          tenantId: BigInt(companyTenantId),
+          tenantId: { in: ctx.tenantIds.map(BigInt) },
           isActive: true,
         },
         orderBy: { name: 'asc' },
@@ -228,7 +256,7 @@ export const registerInternshipHiringRoutes = (
     handler: async (request, reply) => {
       const ctx = getRequestContext(request);
       const { functionalGroupId, roleId } = request.query as Record<string, string | undefined>;
-      const companyTenantId = resolveCompanyTenantId(ctx, request);
+      const companyTenantId = resolveCompanyTenantId(ctx);
       logger.debug('Listing PWOs for internship', { ...getLogContext(request), userId: ctx.actorUserAccountId, tenantId: ctx.tenantId });
 
       if (!companyTenantId || !functionalGroupId) {
@@ -459,13 +487,21 @@ export const registerInternshipHiringRoutes = (
         },
       });
 
-      // Resolve mentor names
+      // Resolve mentor names (derive a friendly name from email: john.doe@x → "John Doe")
       const mentorIds = [...new Set(plans.map(p => p.mentorUserId))];
       const mentorUsers = await prisma.userAccount.findMany({
         where: { id: { in: mentorIds } },
         select: { id: true, publicUuid: true, primaryEmail: true },
       });
-      const mentorMap = new Map(mentorUsers.map(u => [u.id, { id: u.publicUuid, name: u.primaryEmail }]));
+      const mentorMap = new Map(
+        mentorUsers.map(u => {
+          const name = u.primaryEmail.split('@')[0]
+            .split(/[._-]/)
+            .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+            .join(' ');
+          return [u.id, { id: u.publicUuid, name }];
+        }),
+      );
 
       const data = plans.map(p => {
         const ciParts = [p.capabilityInstance.swo?.name, p.capabilityInstance.capability.name, p.capabilityInstance.proficiency.label].filter(Boolean);

--- a/apps/web/admin-portal/src/app/core/services/auth-context.service.ts
+++ b/apps/web/admin-portal/src/app/core/services/auth-context.service.ts
@@ -23,7 +23,6 @@ export class AuthContextService {
   readonly tenantId   = signal<string>('');
   readonly userId     = signal<string>('');
   readonly isLoaded   = signal(false);
-  readonly selectedCompanyTenantId = signal<string | null>(null);
   readonly selectedTenantId = signal<string | null>(null);
   readonly tenantOptions = signal<TenantOption[]>([]);
   readonly isAdmin = computed(() => this.tenantType() === 'SYSTEM');

--- a/apps/web/admin-portal/src/app/pages/manage-internship/components/internship-detail-panel/internship-detail-panel.component.html
+++ b/apps/web/admin-portal/src/app/pages/manage-internship/components/internship-detail-panel/internship-detail-panel.component.html
@@ -41,13 +41,13 @@
           <div class="flex items-center gap-3 mb-3">
             @if (internship()!.bannerImageUrl) {
               <img
-                [src]="internship()!.bannerImageUrl | signedUrl"
+                [src]="internship().bannerImageUrl | signedUrl"
                 [alt]="internship()!.title"
                 class="w-15 h-15 rounded-lg object-cover shrink-0"
               />
             } @else {
               <div
-                class="w-15 h-15 rounded-lg bg-whizard-action flex items-center justify-center text-whizard-text-primary text-2xl font-bold shrink-0"
+                class="w-[60px] h-[60px] rounded-lg bg-whizard-action flex items-center justify-center text-whizard-text-primary text-2xl font-bold shrink-0"
               >
                 {{ internship()!.title.charAt(0).toUpperCase() }}
               </div>
@@ -889,19 +889,29 @@
                 </mat-expansion-panel-header>
 
                 <div class="space-y-5 pt-2">
-                  <!-- Capability Instance + Skill -->
+                  <!-- Skill -->
                   <div>
                     <p
                       class="text-[15px] font-medium text-whizard-text-tertiary tracking-[0.15px]"
                     >
-                      Capability Instance + Skill
+                      Skill
                     </p>
-                    <p
-                      class="text-[14px] text-whizard-text-primary leading-5.5 mt-1"
-                    >
-                      {{ week.capabilityInstanceName
-                      }}{{ week.skillNames ? '+' + week.skillNames : '' }}
-                    </p>
+                    <div class="flex items-center gap-2 mt-1">
+                      <p
+                        class="text-[14px] text-whizard-text-primary leading-5.5"
+                      >
+                        {{ week.skillNames || '—' }}
+                      </p>
+                      <a
+                        href="https://s3.eu-central-2.wasabisys.com/dbdumps/html/Rotor_Blade_L1_Course.html"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="ml-auto inline-flex items-center gap-1.5 h-8 px-3 rounded-lg bg-whizard-action hover:bg-whizard-action-hover text-whizard-text-primary text-[13px] font-medium shrink-0 transition-colors"
+                      >
+                        <mat-icon class="!text-[16px] !w-4 !h-4">open_in_new</mat-icon>
+                        View Course
+                      </a>
+                    </div>
                   </div>
 
                   <!-- Tasks -->

--- a/apps/web/admin-portal/src/app/pages/manage-internship/manage-internship.component.ts
+++ b/apps/web/admin-portal/src/app/pages/manage-internship/manage-internship.component.ts
@@ -225,7 +225,7 @@ export class ManageInternshipComponent implements OnInit, OnDestroy {
 
   private loadFormDropdowns(companyTenantId?: string | null): void {
     if (companyTenantId && this.isAdminOrSystemUser()) {
-      this.authCtx.selectedCompanyTenantId.set(companyTenantId);
+      this.authCtx.setSelectedTenantId(companyTenantId);
     }
     this.api.listCities().subscribe(c => this.cities.set(c));
     this.api.listIndustryRoles().subscribe(r => this.industryRoles.set(r));
@@ -273,7 +273,7 @@ export class ManageInternshipComponent implements OnInit, OnDestroy {
   }
 
   protected onCompanySelected(tenantId: string): void {
-    this.authCtx.selectedCompanyTenantId.set(tenantId || null);
+    this.authCtx.setSelectedTenantId(tenantId || null);
     this.loadList();
     if (this.mode() === 'create' || this.mode() === 'edit') {
       this.loadFormDropdowns();

--- a/apps/web/admin-portal/src/app/pages/manage-internship/services/manage-internship-api.service.ts
+++ b/apps/web/admin-portal/src/app/pages/manage-internship/services/manage-internship-api.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable, map } from 'rxjs';
 import type {
@@ -17,34 +17,20 @@ import type {
   InternshipPlanItem,
 } from '../models/manage-internship.models';
 import { environment } from '../../../../environments/environment';
-import { AuthContextService } from '../../../core/services/auth-context.service';
 
 interface ApiEnvelope<T> { success: boolean; data: T; }
 
 @Injectable({ providedIn: 'root' })
 export class ManageInternshipApiService {
   private readonly http = inject(HttpClient);
-  private readonly authCtx = inject(AuthContextService);
   private readonly base = `${environment.bffApiUrl}/internships`;
-
-  private companyHeaders(): { headers?: HttpHeaders } {
-    const type = this.authCtx.tenantType();
-    const tenantId =
-      type === 'COMPANY'
-        ? this.authCtx.tenantId()                     // company user → use their own tenant
-        : (type === 'ADMIN' || type === 'SYSTEM')
-          ? this.authCtx.selectedCompanyTenantId()    // admin/system → use selected company
-          : null;
-    if (!tenantId) return {};
-    return { headers: new HttpHeaders({ 'X-Company-Tenant-Id': tenantId }) };
-  }
 
   listInternships(search?: string, status?: string): Observable<InternshipDetail[]> {
     const params: Record<string, string> = {};
     if (search) params['search'] = search;
     if (status) params['status'] = status;
     return this.http
-      .get<ApiEnvelope<InternshipDetail[]>>(this.base, { params, ...this.companyHeaders() })
+      .get<ApiEnvelope<InternshipDetail[]>>(this.base, { params })
       .pipe(map(r => r.data));
   }
 
@@ -56,7 +42,7 @@ export class ManageInternshipApiService {
 
   createInternship(form: InternshipFormValue): Observable<InternshipDetail> {
     return this.http
-      .post<ApiEnvelope<InternshipDetail>>(this.base, form, this.companyHeaders())
+      .post<ApiEnvelope<InternshipDetail>>(this.base, form)
       .pipe(map(r => r.data));
   }
 
@@ -80,13 +66,13 @@ export class ManageInternshipApiService {
 
   listCities(): Observable<City[]> {
     return this.http
-      .get<ApiEnvelope<City[]>>(`${environment.bffApiUrl}/companies/cities`, this.companyHeaders())
+      .get<ApiEnvelope<City[]>>(`${environment.bffApiUrl}/companies/cities`)
       .pipe(map(r => r.data));
   }
 
   listIndustryRoles(): Observable<IndustryRole[]> {
     return this.http
-      .get<ApiEnvelope<IndustryRole[]>>(`${this.base}/roles`, this.companyHeaders())
+      .get<ApiEnvelope<IndustryRole[]>>(`${this.base}/roles`)
       .pipe(map(r => r.data));
   }
 
@@ -98,7 +84,7 @@ export class ManageInternshipApiService {
 
   listCoordinators(): Observable<CoordinatorUser[]> {
     return this.http
-      .get<ApiEnvelope<CoordinatorUser[]>>(`${this.base}/coordinators`, this.companyHeaders())
+      .get<ApiEnvelope<CoordinatorUser[]>>(`${this.base}/coordinators`)
       .pipe(map(r => r.data));
   }
 
@@ -106,7 +92,7 @@ export class ManageInternshipApiService {
     const opts: Record<string, string> = {};
     if (roleId) opts['roleId'] = roleId;
     return this.http
-      .get<ApiEnvelope<FunctionalGroup[]>>(`${this.base}/functional-groups`, { params: opts, ...this.companyHeaders() })
+      .get<ApiEnvelope<FunctionalGroup[]>>(`${this.base}/functional-groups`, { params: opts })
       .pipe(map(r => r.data));
   }
 
@@ -114,31 +100,31 @@ export class ManageInternshipApiService {
     const params: Record<string, string> = { functionalGroupId };
     if (roleId) params['roleId'] = roleId;
     return this.http
-      .get<ApiEnvelope<PwoItem[]>>(`${this.base}/pwos`, { params, ...this.companyHeaders() })
+      .get<ApiEnvelope<PwoItem[]>>(`${this.base}/pwos`, { params })
       .pipe(map(r => r.data));
   }
 
   listCapabilityInstances(pwoId: string): Observable<CapabilityInstanceItem[]> {
     return this.http
-      .get<ApiEnvelope<CapabilityInstanceItem[]>>(`${this.base}/capability-instances`, { params: { pwoId }, ...this.companyHeaders() })
+      .get<ApiEnvelope<CapabilityInstanceItem[]>>(`${this.base}/capability-instances`, { params: { pwoId } })
       .pipe(map(r => r.data));
   }
 
   listSkills(capabilityInstanceId: string): Observable<SkillItem[]> {
     return this.http
-      .get<ApiEnvelope<SkillItem[]>>(`${this.base}/skills`, { params: { capabilityInstanceId }, ...this.companyHeaders() })
+      .get<ApiEnvelope<SkillItem[]>>(`${this.base}/skills`, { params: { capabilityInstanceId } })
       .pipe(map(r => r.data));
   }
 
   listTasks(skillIds: string[]): Observable<TaskItem[]> {
     return this.http
-      .get<ApiEnvelope<TaskItem[]>>(`${this.base}/tasks`, { params: { skillIds: skillIds.join(',') }, ...this.companyHeaders() })
+      .get<ApiEnvelope<TaskItem[]>>(`${this.base}/tasks`, { params: { skillIds: skillIds.join(',') } })
       .pipe(map(r => r.data));
   }
 
   getPlans(internshipId: string): Observable<InternshipPlanItem[]> {
     return this.http
-      .get<ApiEnvelope<InternshipPlanItem[]>>(`${this.base}/${internshipId}/plans`, this.companyHeaders())
+      .get<ApiEnvelope<InternshipPlanItem[]>>(`${this.base}/${internshipId}/plans`)
       .pipe(map(r => r.data));
   }
 
@@ -150,7 +136,7 @@ export class ManageInternshipApiService {
     schedules?: Array<{ taskId: string; weekNumber: number; orderIndex: number; evidence: string }>;
   }>): Observable<{ saved: boolean }> {
     return this.http
-      .post<ApiEnvelope<{ saved: boolean }>>(`${this.base}/${internshipId}/plans`, { plans }, this.companyHeaders())
+      .post<ApiEnvelope<{ saved: boolean }>>(`${this.base}/${internshipId}/plans`, { plans })
       .pipe(map(r => r.data));
   }
 

--- a/libs/contexts/capability-framework/src/application/command-handlers/industry-role.handlers.ts
+++ b/libs/contexts/capability-framework/src/application/command-handlers/industry-role.handlers.ts
@@ -22,7 +22,7 @@ export class CreateIndustryRoleCommandHandler {
     const role = IndustryRole.create({
       tenantId: cmd.tenantId,
       departmentId: cmd.departmentId,
-      industryId: cmd.industryId,
+      industryId: cmd.industryId ?? dept.industryId,
       name: cmd.name,
       description: cmd.description,
       seniorityLevel: cmd.seniorityLevel,

--- a/libs/contexts/internship-hiring/src/application/queries/list-internships.query.ts
+++ b/libs/contexts/internship-hiring/src/application/queries/list-internships.query.ts
@@ -1,6 +1,7 @@
 export interface ListInternshipsQuery {
   tenantId: string;
   companyTenantId?: string;
+  allTenants?: boolean;
   search?: string;
   status?: string;
 }

--- a/libs/contexts/internship-hiring/src/application/query-handlers/list-internships.handler.ts
+++ b/libs/contexts/internship-hiring/src/application/query-handlers/list-internships.handler.ts
@@ -10,6 +10,7 @@ export class ListInternshipsQueryHandler {
     const internships = await this.repo.findAll({
       tenantId:        query.tenantId,
       companyTenantId: query.companyTenantId,
+      allTenants:      query.allTenants,
       search:          query.search,
       status:          query.status,
     });

--- a/libs/contexts/internship-hiring/src/domain/repositories/internship.repository.ts
+++ b/libs/contexts/internship-hiring/src/domain/repositories/internship.repository.ts
@@ -3,6 +3,7 @@ import type { Internship } from '../aggregates/internship.aggregate.js';
 export interface InternshipListFilter {
   tenantId: string;
   companyTenantId?: string;
+  allTenants?: boolean;
   search?: string;
   status?: string;
 }

--- a/libs/contexts/internship-hiring/src/infrastructure/persistence/postgres/prisma-internship.repository.ts
+++ b/libs/contexts/internship-hiring/src/infrastructure/persistence/postgres/prisma-internship.repository.ts
@@ -57,9 +57,12 @@ export class PrismaInternshipRepository implements IInternshipRepository {
     // When a company is selected, scope by companyTenantId alone so results include
     // both company-owned internships (tenantId = company) and system-owned internships
     // assigned to that company (tenantId = system, companyTenantId = company).
-    const scopeFilter = filter.companyTenantId
-      ? { companyTenantId: BigInt(filter.companyTenantId) }
-      : { tenantId };
+    // When allTenants is set (SYSTEM admin viewing global scope), skip scope filter entirely.
+    const scopeFilter = filter.allTenants
+      ? {}
+      : filter.companyTenantId
+        ? { companyTenantId: BigInt(filter.companyTenantId) }
+        : { tenantId };
     const rows = await this.prisma.internship.findMany({
       where: {
         ...scopeFilter,

--- a/libs/shared/ui/src/signed-url/signed-url.pipe.ts
+++ b/libs/shared/ui/src/signed-url/signed-url.pipe.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectorRef, OnDestroy, Pipe, PipeTransform, inject } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  OnDestroy,
+  Pipe,
+  PipeTransform,
+  inject,
+} from '@angular/core';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { SIGNED_URL_PROVIDER } from './signed-url.token.js';
 
@@ -8,7 +14,7 @@ interface CacheEntry {
 }
 
 const cache = new Map<string, CacheEntry>();
-const CACHE_TTL_MS = 4 * 60 * 1000; // 4 min (signed URLs last 5 min)
+const CACHE_TTL_MS = 5 * 60 * 1000; // 4 min (signed URLs last 5 min)
 
 @Pipe({ name: 'signedUrl', standalone: true, pure: false })
 export class SignedUrlPipe implements PipeTransform, OnDestroy {
@@ -40,18 +46,35 @@ export class SignedUrlPipe implements PipeTransform, OnDestroy {
     this.loading = true;
     this.resolvedUrl = '';
 
-    this.provider.getSignedUrl(key).subscribe({
-      next: (url) => {
-        cache.set(key, { url, expiresAt: Date.now() + CACHE_TTL_MS });
-        this.resolvedUrl = this.sanitizer.bypassSecurityTrustUrl(url);
-        this.loading = false;
-        this.cdr.markForCheck();
-      },
-      error: () => {
-        this.loading = false;
-        this.cdr.markForCheck();
-      },
-    });
+    setTimeout(() => {
+      this.provider.getSignedUrl(key).subscribe({
+        next: (url) => {
+          cache.set(key, { url, expiresAt: Date.now() + CACHE_TTL_MS });
+          this.resolvedUrl = this.sanitizer.bypassSecurityTrustUrl(url);
+          this.loading = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.loading = false;
+          this.cdr.markForCheck();
+        },
+      });
+    }, 0);
+
+    // queueMicrotask(() => {
+    //   this.provider.getSignedUrl(key).subscribe({
+    //     next: (url) => {
+    //       cache.set(key, { url, expiresAt: Date.now() + CACHE_TTL_MS });
+    //       this.resolvedUrl = this.sanitizer.bypassSecurityTrustUrl(url);
+    //       this.loading = false;
+    //       this.cdr.markForCheck();
+    //     },
+    //     error: () => {
+    //       this.loading = false;
+    //       this.cdr.markForCheck();
+    //     },
+    //   });
+    // });
 
     return this.resolvedUrl;
   }


### PR DESCRIPTION
* Replace `X-Company-Tenant-Id` with `X-Selected-Tenant-Id` in BFF/Core API
* Allow SYSTEM admins to list internships and roles across all tenants when no company is selected
* Consolidate `selectedCompanyTenantId` into shared `selectedTenantId` signal in admin portal
* Derive mentor display name from email local-part
* Fallback industry role `industryId` to parent department on create
* Defer `signedUrl` pipe resolution via `setTimeout` to avoid NG0100